### PR TITLE
[WIP] Travis Support + Linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ install:
   - pip install .
   - bots_api/provision.py
 script:
-  # TODO run linter here
+  - tools/lint
   - bots_api/test-bots

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7"
+install:
+  - pip install .
+  - bots_api/provision.py
+script:
+  # TODO run linter here
+  - bots_api/test-bots

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,8 @@ setuptools_info = dict(
                       'typing>=3.5.2.2',
                       'flask>=0.12.2',
                       'mock>=2.0.0',
+                      # for pep8 linter
+                      'pycodestyle==2.3.1',
                       ],
 )
 

--- a/tools/lint
+++ b/tools/lint
@@ -1,0 +1,36 @@
+#! /usr/bin/env python
+
+from pep8 import check_pep8
+from server_lib import lister
+
+import sys
+import optparse
+from typing import cast, Callable, Dict, Iterator, List
+
+EXCLUDED_FILES = [
+    # This is an external file that doesn't comply with our codestyle
+    'integrations/perforce/git_p4.py',
+]
+
+def lint_all(args, options):
+
+    by_lang = cast(Dict[str, List[str]],
+                   lister.list_files(args, modified_only=options.modified,
+                                     ftypes=['py', 'sh', 'js', 'pp', 'css', 'handlebars',
+                                             'html', 'json', 'md', 'txt', 'text', 'yaml'],
+                                     use_shebang=True, group_by_ftype=True, exclude=EXCLUDED_FILES))
+    failed = check_pep8(by_lang['py'])
+    return failed
+
+def run():
+    # type: () -> None
+    parser = optparse.OptionParser()
+    parser.add_option('--modified', '-m',
+                      action='store_true',
+                      help='Only check modified files')
+    (options, args) = parser.parse_args()
+    failed = lint_all(args, options)
+    sys.exit(1 if failed else 0)
+
+if __name__ == '__main__':
+    run()

--- a/tools/pep8.py
+++ b/tools/pep8.py
@@ -1,0 +1,99 @@
+# This file has been copied and modified from the Zulip server repository
+# Original path: zulip/tools/linter_lib/pep8.py
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+import subprocess
+import sys
+
+from server_lib.printer import print_err, colors
+
+from typing import List
+
+def check_pep8(files):
+    # type: (List[str]) -> bool
+
+    def run_pycodestyle(files, ignored_rules):
+        # type: (List[str], List[str]) -> bool
+        failed = False
+        color = next(colors)
+        pep8 = subprocess.Popen(
+            ['pycodestyle'] + files + ['--ignore={rules}'.format(rules=','.join(ignored_rules))],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        for line in iter(pep8.stdout.readline, b''):
+            print_err('pep8', color, line)
+            failed = True
+        return failed
+
+    failed = False
+    ignored_rules = [
+        # Each of these rules are ignored for the explained reason.
+
+        # "multiple spaces before operator"
+        # There are several typos here, but also several instances that are
+        # being used for alignment in dict keys/values using the `dict`
+        # constructor. We could fix the alignment cases by switching to the `{}`
+        # constructor, but it makes fixing this rule a little less
+        # straightforward.
+        'E221',
+
+        # 'missing whitespace around arithmetic operator'
+        # This should possibly be cleaned up, though changing some of
+        # these may make the code less readable.
+        'E226',
+
+        # "unexpected spaces around keyword / parameter equals"
+        # Many of these should be fixed, but many are also being used for
+        # alignment/making the code easier to read.
+        'E251',
+
+        # "block comment should start with '#'"
+        # These serve to show which lines should be changed in files customized
+        # by the user. We could probably resolve one of E265 or E266 by
+        # standardizing on a single style for lines that the user might want to
+        # change.
+        'E265',
+
+        # "too many leading '#' for block comment"
+        # Most of these are there for valid reasons.
+        'E266',
+
+        # "expected 2 blank lines after class or function definition"
+        # Zulip only uses 1 blank line after class/function
+        # definitions; the PEP-8 recommendation results in super sparse code.
+        'E302', 'E305',
+
+        # "module level import not at top of file"
+        # Most of these are there for valid reasons, though there might be a
+        # few that could be eliminated.
+        'E402',
+
+        # "line too long"
+        # Zulip is a bit less strict about line length, and has its
+        # own check for this (see max_length)
+        'E501',
+
+        # "do not assign a lambda expression, use a def"
+        # Fixing these would probably reduce readability in most cases.
+        'E731',
+    ]
+
+    # TODO: Clear up this list of violations.
+    IGNORE_FILES_PEPE261 = []
+
+    filtered_files = [fn for fn in files if fn not in IGNORE_FILES_PEPE261]
+    filtered_files_E261 = [fn for fn in files if fn in IGNORE_FILES_PEPE261]
+
+    if len(files) == 0:
+        return False
+    if not len(filtered_files) == 0:
+        failed = run_pycodestyle(filtered_files, ignored_rules)
+    if not len(filtered_files_E261) == 0:
+        # Adding an extra ignore rule for these files since they still remain in
+        # violation of PEP-E261.
+        failed_ignore_e261 = run_pycodestyle(filtered_files_E261, ignored_rules + ['E261'])
+        if not failed:
+            failed = failed_ignore_e261
+
+    return failed

--- a/tools/server_lib/README.md
+++ b/tools/server_lib/README.md
@@ -1,0 +1,10 @@
+# Server Lib
+
+This directory contains file copied as is from the [zulip server repository](https://github.com/zulip/zulip) as they were on the commit `343cb20d570a8f5c1f5b6e6842058b294a376593`.
+
+## List of copied files
+
+Any changes made to these files have been marked using git's conflict markers in the files.
+
+1. `lister.py` <- `zulip/tools/lister.py` - No changes
+2. `printer.py` <- `zulip/tools/linter_lib/printer.py` - Minor changes

--- a/tools/server_lib/lister.py
+++ b/tools/server_lib/lister.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from __future__ import absolute_import
+
+import os
+from os.path import abspath
+import sys
+import subprocess
+import re
+from collections import defaultdict
+import argparse
+from six.moves import filter
+
+from typing import Union, List, Dict
+
+def get_ftype(fpath, use_shebang):
+    # type: (str, bool) -> str
+    ext = os.path.splitext(fpath)[1]
+    if ext:
+        return ext[1:]
+    elif use_shebang:
+        # opening a file may throw an OSError
+        with open(fpath) as f:
+            first_line = f.readline()
+            if re.search(r'^#!.*\bpython', first_line):
+                return 'py'
+            elif re.search(r'^#!.*sh', first_line):
+                return 'sh'
+            elif re.search(r'^#!.*\bperl', first_line):
+                return 'pl'
+            elif re.search(r'^#!.*\bnode', first_line):
+                return 'js'
+            elif re.search(r'^#!.*\bruby', first_line):
+                return 'rb'
+            elif re.search(r'^#!', first_line):
+                print('Error: Unknown shebang in file "%s":\n%s' % (fpath, first_line), file=sys.stderr)
+                return ''
+            else:
+                return ''
+    else:
+        return ''
+
+def list_files(targets=[], ftypes=[], use_shebang=True, modified_only=False,
+               exclude=[], group_by_ftype=False, extless_only=False):
+    # type: (List[str], List[str], bool, bool, List[str], bool, bool) -> Union[Dict[str, List[str]], List[str]]
+    """
+    List files tracked by git.
+
+    Returns a list of files which are either in targets or in directories in targets.
+    If targets is [], list of all tracked files in current directory is returned.
+
+    Other arguments:
+    ftypes - List of file types on which to filter the search.
+        If ftypes is [], all files are included.
+    use_shebang - Determine file type of extensionless files from their shebang.
+    modified_only - Only include files which have been modified.
+    exclude - List of paths to be excluded, relative to repository root.
+    group_by_ftype - If True, returns a dict of lists keyed by file type.
+        If False, returns a flat list of files.
+    extless_only - Only include extensionless files in output.
+    """
+    ftypes = [x.strip('.') for x in ftypes]
+    ftypes_set = set(ftypes)
+
+    # Really this is all bytes -- it's a file path -- but we get paths in
+    # sys.argv as str, so that battle is already lost.  Settle for hoping
+    # everything is UTF-8.
+    repository_root = subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).strip().decode('utf-8')
+    exclude_abspaths = [os.path.join(repository_root, fpath).rstrip('/') for fpath in exclude]
+
+    cmdline = ['git', 'ls-files'] + targets
+    if modified_only:
+        cmdline.append('-m')
+
+    files_gen = (x.strip() for x in subprocess.check_output(cmdline, universal_newlines=True).split('\n'))
+    # throw away empty lines and non-files (like symlinks)
+    files = list(filter(os.path.isfile, files_gen))
+
+    result_dict = defaultdict(list)  # type: Dict[str, List[str]]
+    result_list = []  # type: List[str]
+
+    for fpath in files:
+        # this will take a long time if exclude is very large
+        ext = os.path.splitext(fpath)[1]
+        if extless_only and ext:
+            continue
+        absfpath = abspath(fpath)
+        if any(absfpath == expath or absfpath.startswith(expath + '/')
+               for expath in exclude_abspaths):
+            continue
+
+        if ftypes or group_by_ftype:
+            try:
+                filetype = get_ftype(fpath, use_shebang)
+            except (OSError, UnicodeDecodeError) as e:
+                etype = e.__class__.__name__
+                print('Error: %s while determining type of file "%s":' % (etype, fpath), file=sys.stderr)
+                print(e, file=sys.stderr)
+                filetype = ''
+            if ftypes and filetype not in ftypes_set:
+                continue
+
+        if group_by_ftype:
+            result_dict[filetype].append(fpath)
+        else:
+            result_list.append(fpath)
+
+    if group_by_ftype:
+        return result_dict
+    else:
+        return result_list
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="List files tracked by git and optionally filter by type")
+    parser.add_argument('targets', nargs='*', default=[],
+                        help='''files and directories to include in the result.
+                        If this is not specified, the current directory is used''')
+    parser.add_argument('-m', '--modified', action='store_true', default=False, help='list only modified files')
+    parser.add_argument('-f', '--ftypes', nargs='+', default=[],
+                        help="list of file types to filter on. All files are included if this option is absent")
+    parser.add_argument('--ext-only', dest='extonly', action='store_true', default=False,
+                        help='only use extension to determine file type')
+    parser.add_argument('--exclude', nargs='+', default=[],
+                        help='list of files and directories to exclude from results, relative to repo root')
+    parser.add_argument('--extless-only', dest='extless_only', action='store_true', default=False,
+                        help='only include extensionless files in output')
+    args = parser.parse_args()
+    listing = list_files(targets=args.targets, ftypes=args.ftypes, use_shebang=not args.extonly,
+                         modified_only=args.modified, exclude=args.exclude, extless_only=args.extless_only)
+    for l in listing:
+        print(l)

--- a/tools/server_lib/printer.py
+++ b/tools/server_lib/printer.py
@@ -1,0 +1,51 @@
+from __future__ import print_function, absolute_import
+
+import sys
+import os
+from itertools import cycle
+
+# <<<<<<< zulip/zulip
+# sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
+# from scripts.lib.zulip_tools import ENDC, BOLDRED, GREEN, YELLOW, BLUE, MAGENTA, CYAN
+# =======
+# Color codes
+OKBLUE = '\033[94m'
+OKGREEN = '\033[92m'
+WARNING = '\033[93m'
+FAIL = '\033[91m'
+ENDC = '\033[0m'
+BLACKONYELLOW = '\x1b[0;30;43m'
+WHITEONRED = '\x1b[0;37;41m'
+BOLDRED = '\x1B[1;31m'
+
+GREEN = '\x1b[32m'
+YELLOW = '\x1b[33m'
+BLUE = '\x1b[34m'
+MAGENTA = '\x1b[35m'
+CYAN = '\x1b[36m'
+# >>>>>>> zulip/python-zulip-api
+
+from typing import Union, Text
+
+colors = cycle([GREEN, YELLOW, BLUE, MAGENTA, CYAN])
+
+
+def print_err(name, color, line):
+    # type: (str, str, Union[Text, bytes]) -> None
+
+    # Decode with UTF-8 if in Python 3 and `line` is of bytes type.
+    # (Python 2 does this automatically)
+    if sys.version_info[0] == 3 and isinstance(line, bytes):
+        line = line.decode('utf-8')
+
+    print('{}{}{}|{end} {}{}{end}'.format(
+        color,
+        name,
+        ' ' * max(0, 10 - len(name)),
+        BOLDRED,
+        line.rstrip(),
+        end=ENDC)
+    )
+
+    # Python 2's print function does not have a `flush` option.
+    sys.stdout.flush()

--- a/zulip/__init__.py
+++ b/zulip/__init__.py
@@ -105,7 +105,7 @@ def _default_client():
 
 def generate_option_group(parser, prefix=''):
     # type: (optparse.OptionParser, str) ->  optparse.OptionGroup
-    group = optparse.OptionGroup(parser, 'Zulip API configuration') # type: ignore # https://github.com/python/typeshed/pull/1248
+    group = optparse.OptionGroup(parser, 'Zulip API configuration')  # type: ignore # https://github.com/python/typeshed/pull/1248
     group.add_option('--%ssite' % (prefix,),
                      dest="zulip_site",
                      help="Zulip server URI",


### PR DESCRIPTION
This particular commit should fail tests. I'll add another to fix them.

Results:

https://travis-ci.org/aero31aero/python-zulip-api/builds/250967292

```bash
1.72s$ tools/lint

pep8      | tools/lint:9:15: E225 missing whitespace around operator

pep8      | tools/lint:10:1: W191 indentation contains tabs

pep8      | tools/lint:10:5: E126 continuation line over-indented for hanging indent

pep8      | tools/lint:11:1: W191 indentation contains tabs

pep8      | tools/lint:12:1: W191 indentation contains tabs

pep8      | tools/lint:12:4: E126 continuation line over-indented for hanging indent

pep8      | tools/lint:16:1: W191 indentation contains tabs

pep8      | tools/lint:17:1: W191 indentation contains tabs

pep8      | tools/lint:17:5: E101 indentation contains mixed spaces and tabs

pep8      | tools/lint:17:8: E128 continuation line under-indented for visual indent

pep8      | tools/lint:18:1: W191 indentation contains tabs

pep8      | tools/lint:18:2: E101 indentation contains mixed spaces and tabs

pep8      | tools/lint:19:1: W191 indentation contains tabs

pep8      | tools/lint:19:2: E101 indentation contains mixed spaces and tabs

pep8      | tools/lint:20:1: W191 indentation contains tabs

pep8      | tools/lint:20:2: E101 indentation contains mixed spaces and tabs

pep8      | tools/lint:21:1: W191 indentation contains tabs

pep8      | tools/lint:22:1: W191 indentation contains tabs

pep8      | tools/lint:25:1: E101 indentation contains mixed spaces and tabs

pep8      | tools/lint:40:13: E222 multiple spaces after operator

pep8      | zulip/__init__.py:108:68: E261 at least two spaces before inline comment

Traceback (most recent call last):
```