### PR TITLE
zulip_bots/run: Support importing bot modules by path.

### DIFF
--- a/tools/test-bots
+++ b/tools/test-bots
@@ -1,72 +1,80 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
-from __future__ import print_function
-
+from os.path import dirname, basename
+from importlib import import_module
 import argparse
 import os
-import sys
+import glob
 import unittest
 import logging
-from unittest import TestCase
 
-def dir_join(dir1, dir2):
-    # type: (str, str) -> str
-    return os.path.abspath(os.path.join(dir1, dir2))
+
+def load_tests_from_modules(names, template):
+    loader = unittest.defaultTestLoader
+    test_suites = []
+
+    for name in names:
+        module = import_module(template.format(name=name))
+        test_suites.append(loader.loadTestsFromModule(module))
+
+    return test_suites
+
+
+def parse_args(available_bots):
+    description = """
+Script to run test_<bot_name>.py files in the
+zulip_bot/zulip_bots/bots/<bot_name> directories.
+
+Running tests for all bots:
+
+./test-bots
+
+Running tests for specific bots:
+
+./test-bots define thesaurus
+
+Running tests for all bots excluding certain bots (the
+following command would run tests for all bots except
+the tests for xkcd and wikipedia bots):
+
+./test-bots --exclude xkcd wikipedia
+"""
+    parser = argparse.ArgumentParser(description=description)
+
+    parser.add_argument('bots_to_test',
+                        metavar='bot',
+                        nargs='*',
+                        default=available_bots,
+                        help='specific bots to test (default is all)')
+
+    parser.add_argument('--exclude',
+                        metavar='bot',
+                        nargs='*',
+                        default=[],
+                        help='bot(s) to exclude')
+    return parser.parse_args()
+
+
+def main():
+    glob_pattern = os.path.abspath('../zulip_bots/zulip_bots/bots/*/test_*.py')
+    test_modules = glob.glob(glob_pattern)
+
+    # get only the names of bots that have tests
+    available_bots = map(lambda path: basename(dirname(path)), test_modules)
+
+    options = parse_args(available_bots)
+
+    bots_to_test = filter(lambda bot: bot not in options.exclude,
+                          options.bots_to_test)
+    test_suites = load_tests_from_modules(
+        bots_to_test,
+        template='zulip_bots.bots.{name}.test_{name}'
+    )
+
+    suite = unittest.TestSuite(test_suites)
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite)
 
 
 if __name__ == '__main__':
-
-    tools_dir = os.path.dirname(os.path.abspath(__file__))
-    bots_dir = os.path.join(tools_dir, '..', 'zulip_bots', 'zulip_bots')
-    bots_test_dir = dir_join(bots_dir, 'bots')
-
-    sys.path.insert(0, bots_dir)
-    sys.path.insert(0, bots_test_dir)
-
-    btd = bots_test_dir
-    available_bots = [b for b in os.listdir(btd) if os.path.isdir(dir_join(btd, b))]
-
-    description = 'Script to run test_<bot>.py files in api/bots/<bot> directories'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument('bots_to_test', metavar='bot', nargs='*', default=available_bots,
-                        help='specific bots to test (default is all)')
-    parser.add_argument('--exclude', metavar='bot', action='append', default=[],
-                        help='specific bot to exclude (can be used multiple times)')
-    args = parser.parse_args()
-
-    failed = False
-    if args.bots_to_test != available_bots and len(args.bots_to_test) > 0:
-        for n in args.bots_to_test:
-            if n not in available_bots:
-                logging.warning("Bot with name '%s' is unavailable for testing." % (n))
-                args.bots_to_test.remove(n)
-                failed = True
-
-    for to_exclude in args.exclude:
-        if to_exclude in args.bots_to_test:
-            args.bots_to_test.remove(to_exclude)
-
-    # mypy doesn't recognize the TestLoader attribute, even though the code
-    # is executable
-    loader = unittest.TestLoader()  # type: ignore
-
-    suites = []
-    for bot_to_test in args.bots_to_test:
-        dep_path = os.path.join(bots_test_dir, bot_to_test, 'bot_dependencies')
-        sys.path.insert(0, dep_path)
-        try:
-            suites.append(loader.discover(start_dir = dir_join(bots_test_dir, bot_to_test),
-                                          top_level_dir = bots_dir))
-        except ImportError:
-            logging.error("Bot %s requires __init__.py to be added" % (bot_to_test))
-            failed = True
-
-    suite = unittest.TestSuite(suites)
-    runner = unittest.TextTestRunner(verbosity=2)
-    # same issue as for TestLoader
-    result = runner.run(suite)  # type: ignore
-    if result.errors or result.failures:
-        raise Exception('Test failed!')
-
-    sys.exit(failed)
+    main()

--- a/tools/test-bots
+++ b/tools/test-bots
@@ -56,7 +56,9 @@ the tests for xkcd and wikipedia bots):
 
 
 def main():
-    glob_pattern = os.path.abspath('../zulip_bots/zulip_bots/bots/*/test_*.py')
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    bots_dir = os.path.join(current_dir, '..', 'zulip_bots/zulip_bots/bots')
+    glob_pattern = bots_dir + '/*/test_*.py'
     test_modules = glob.glob(glob_pattern)
 
     # get only the names of bots that have tests

--- a/zulip_bots/zulip_bots/bots/xkcd/test_xkcd.py
+++ b/zulip_bots/zulip_bots/bots/xkcd/test_xkcd.py
@@ -39,7 +39,7 @@ class TestXkcdBot(BotTestCase):
                         "notation. (??)](https://imgs.xkcd.com/comics/chess_notation.png)")
         with self.mock_http_conversation('test_random'):
             # Mock randint function.
-            with patch('bots.xkcd.xkcd.random.randint') as randint:
+            with patch('zulip_bots.bots.xkcd.xkcd.random.randint') as randint:
                 mock_rand_value = mock.MagicMock()
                 mock_rand_value.return_value = 1800
                 randint.return_value = mock_rand_value.return_value

--- a/zulip_bots/zulip_bots/provision.py
+++ b/zulip_bots/zulip_bots/provision.py
@@ -1,67 +1,87 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-from __future__ import print_function
 
 import argparse
+import logging
 import os
 import sys
+import glob
 import pip
 
 def provision_bot(path_to_bot, force):
     # type: (str, bool) -> None
     req_path = os.path.join(path_to_bot, 'requirements.txt')
     install_path = os.path.join(path_to_bot, 'bot_dependencies')
+
     if os.path.isfile(req_path):
-        print('Installing dependencies...')
+        bot_name = os.path.basename(path_to_bot)
+        logging.info('Installing dependencies for {}...'.format(bot_name))
         if not os.path.isdir(install_path):
             os.makedirs(install_path)
+
         # pip install -r $BASEDIR/requirements.txt -t $BASEDIR/bot_dependencies --quiet
         rcode = pip.main(['install', '-r', req_path, '-t', install_path, '--quiet'])
-        if not rcode == 0:
-            print('Error. Check output of `pip install` above for details.')
+
+        if rcode != 0:
+            logging.error('Error. Check output of `pip install` above for details.')
             if not force:
-                print('Use --force to try running anyway.')
+                logging.error('Use --force to try running anyway.')
                 sys.exit(rcode)  # Use pip's exit code
-        else:
-            print('Installed.')
+
+        if rcode == 0:
+            logging.info('Installed dependencies successfully.')
+
         sys.path.insert(0, install_path)
 
-def dir_join(dir1, dir2):
-    # type: (str, str) -> str
-    return os.path.abspath(os.path.join(dir1, dir2))
 
-def run():
-    # type: () -> None
-    usage = '''
-        Installs dependencies of bots in api/bots directory. Add a
-        reuirements.txt file in a bot's folder before provisioning.
+def parse_args(available_bots):
+    usage = """
+Installs dependencies of bots in the bots/<bot_name>
+directories. Add a requirements.txt file in a bot's folder
+before provisioning.
 
-        To provision all bots, use:
-        ./provision.py
+To provision all bots, use:
+./provision.py
 
-        To provision specific bots, use:
-        ./provision.py [names of bots]
-        Example: ./provision.py helloworld xkcd wikipedia
-
-        '''
-
-    bots_dir = dir_join(os.path.dirname(os.path.abspath(__file__)), 'bots')
-    available_bots = [b for b in os.listdir(bots_dir) if os.path.isdir(dir_join(bots_dir, b))]
-
+To provision specific bots, use:
+./provision.py [names of bots]
+Example: ./provision.py helloworld xkcd wikipedia
+"""
     parser = argparse.ArgumentParser(usage=usage)
+
     parser.add_argument('bots_to_provision',
                         metavar='bots',
                         nargs='*',
                         default=available_bots,
                         help='specific bots to provision (default is all)')
+
     parser.add_argument('--force',
                         default=False,
                         action="store_true",
                         help='Continue installation despite pip errors.')
-    options = parser.parse_args()
+
+    parser.add_argument('--quiet', '-q',
+                        action='store_true',
+                        default=False,
+                        help='Turn off logging output.')
+
+    return parser.parse_args()
+
+
+def main():
+    # type: () -> None
+    bots_dir = os.path.abspath("bots")
+    bots_subdirs = map(os.path.abspath, glob.glob("bots/*"))
+    available_bots = filter(lambda d: os.path.isdir(d), bots_subdirs)
+
+    options = parse_args(available_bots)
+
+    if not options.quiet:
+        logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
     for bot in options.bots_to_provision:
-        provision_bot(os.path.join(dir_join(bots_dir, bot)), options.force)
+        provision_bot(os.path.join(bots_dir, bot), options.force)
 
 if __name__ == '__main__':
-    run()
+    main()

--- a/zulip_bots/zulip_bots/provision.py
+++ b/zulip_bots/zulip_bots/provision.py
@@ -71,8 +71,9 @@ Example: ./provision.py helloworld xkcd wikipedia
 
 def main():
     # type: () -> None
-    bots_dir = os.path.abspath("bots")
-    bots_subdirs = map(os.path.abspath, glob.glob("bots/*"))
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    bots_dir = os.path.join(current_dir, "bots")
+    bots_subdirs = map(os.path.abspath, glob.glob(bots_dir + '/*'))
     available_bots = filter(lambda d: os.path.isdir(d), bots_subdirs)
 
     options = parse_args(available_bots)

--- a/zulip_bots/zulip_bots/run.py
+++ b/zulip_bots/zulip_bots/run.py
@@ -95,7 +95,8 @@ def main():
         lib_module = import_module_from_source(options.path_to_bot, name=options.name)
     elif options.name:
         if options.provision:
-            bots_parent_dir = os.path.abspath("bots")
+            current_dir = os.path.dirname(os.path.abspath(__file__))
+            bots_parent_dir = os.path.join(current_dir, "bots")
             bot_dir = os.path.join(bots_parent_dir, options.name)
             provision_bot(bot_dir, options.force)
         lib_module = import_module('zulip_bots.bots.{bot}.{bot}'.format(bot=options.name))

--- a/zulip_bots/zulip_bots/run.py
+++ b/zulip_bots/zulip_bots/run.py
@@ -7,8 +7,27 @@ import optparse
 import sys
 from types import ModuleType
 from importlib import import_module
+from os.path import basename, splitext
+
+import six
 
 from zulip_bots.lib import run_message_handler_for_bot
+
+
+def import_module_from_source(path, name=None):
+    if name is None:
+        name = splitext(basename(path))[0]
+
+    if six.PY2:
+        import imp
+        module = imp.load_source(name, path)
+        return module
+    else:
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(name, path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
 
 
 def parse_args():
@@ -33,12 +52,22 @@ def parse_args():
                       action='store',
                       help='(alternate config file to ~/.zuliprc)')
 
+    parser.add_option('--path-to-bot',
+                      action='store',
+                      help='path to the file with the bot handler class')
+
     parser.add_option('--force',
                       action='store_true',
                       help='Try running the bot even if dependencies install fails.')
     (options, args) = parser.parse_args()
-    if not args:
-        parser.error('You must specify the name of the bot!')
+
+    if not args and not options.path_to_bot:
+        error_message = """
+You must either specify the name of an existing bot or
+specify a path to the file (--path-to-bot) that contains
+the bot handler class.
+"""
+        parser.error(error_message)
 
     return (options, args)
 
@@ -46,9 +75,16 @@ def parse_args():
 def main():
     # type: () -> None
     (options, args) = parse_args()
-    bot_name = args[0]
 
-    lib_module = import_module('zulip_bots.bots.{bot}.{bot}'.format(bot=bot_name))
+    bot_name = None
+    if args:
+        bot_name = args[0]
+
+    if options.path_to_bot:
+        lib_module = import_module_from_source(options.path_to_bot, name=bot_name)
+    else:
+        lib_module = import_module('zulip_bots.bots.{bot}.{bot}'.format(bot=bot_name))
+
     if not options.quiet:
         logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 


### PR DESCRIPTION
The zulip-run-bot script now supports passing in a --path-to-bot
option. This allows users to specify the path to the source file
for their own custom bots, the first step towards being able to
support out-of-tree bots.

To run an existing bot in the zulip_bots package, just passing in
the name of the bot should suffice.