### PR TITLE
Bots: Add optional contextmanager for StateHandler

### DIFF
--- a/zulip_bots/zulip_bots/bots/incrementor/incrementor.py
+++ b/zulip_bots/zulip_bots/bots/incrementor/incrementor.py
@@ -12,18 +12,16 @@ class IncrementorHandler(object):
         '''
 
     def handle_message(self, message, bot_handler, state_handler):
-        state = state_handler.get_state() or {'number': 0, 'message_id': None}
-        state['number'] += 1
-        state_handler.set_state(state)
-        if state['message_id'] is None:
-            result = bot_handler.send_reply(message, str(state['number']))
-            state['message_id'] = result['id']
-            state_handler.set_state(state)
-        else:
-            bot_handler.update_message(dict(
-                message_id = state['message_id'],
-                content = str(state['number'])
-            ))
+        with state_handler.state({'number': 0, 'message_id': None}) as state:
+            state['number'] += 1
+            if state['message_id'] is None:
+                result = bot_handler.send_reply(message, str(state['number']))
+                state['message_id'] = result['id']
+            else:
+                bot_handler.update_message(dict(
+                    message_id = state['message_id'],
+                    content = str(state['number'])
+                ))
 
 
 handler_class = IncrementorHandler

--- a/zulip_bots/zulip_bots/bots/tictactoe/tictactoe.py
+++ b/zulip_bots/zulip_bots/bots/tictactoe/tictactoe.py
@@ -281,37 +281,31 @@ class ticTacToeHandler(object):
             command += val
         original_sender = message['sender_email']
 
-        mydict = state_handler.get_state()
-        if not mydict:
-            state_handler.set_state({})
-            mydict = state_handler.get_state()
+        with state_handler.state({}) as mydict:
+            user_game = mydict.get(original_sender)
+            if (not user_game) and command == "new":
+                user_game = TicTacToeGame(copy.deepcopy(initial_board))
+                mydict[original_sender] = user_game
 
-        user_game = mydict.get(original_sender)
-        if (not user_game) and command == "new":
-            user_game = TicTacToeGame(copy.deepcopy(initial_board))
-            mydict[original_sender] = user_game
-
-        if command == 'new':
-            if user_game and not first_time(user_game.board):
-                return_content = "You're already playing a game! Type **@tictactoe help** or **@ttt help** to see valid inputs."
+            if command == 'new':
+                if user_game and not first_time(user_game.board):
+                    return_content = "You're already playing a game! Type **@tictactoe help** or **@ttt help** to see valid inputs."
+                else:
+                    return_content = "Welcome to tic-tac-toe! You'll be x's and I'll be o's. Your move first!\n"
+                    return_content += TicTacToeGame.positions
+            elif command == 'help':
+                return_content = TicTacToeGame.detailed_help_message
+            elif (user_game) and TicTacToeGame.check_validity(user_game, TicTacToeGame.sanitize_move(user_game, command)):
+                user_board = user_game.board
+                return_content = TicTacToeGame.tictactoe(user_game, user_board, command)
+            elif (user_game) and command == 'quit':
+                del mydict[original_sender]
+                return_content = "You've successfully quit the game."
             else:
-                return_content = "Welcome to tic-tac-toe! You'll be x's and I'll be o's. Your move first!\n"
-                return_content += TicTacToeGame.positions
-        elif command == 'help':
-            return_content = TicTacToeGame.detailed_help_message
-        elif (user_game) and TicTacToeGame.check_validity(user_game, TicTacToeGame.sanitize_move(user_game, command)):
-            user_board = user_game.board
-            return_content = TicTacToeGame.tictactoe(user_game, user_board, command)
-        elif (user_game) and command == 'quit':
-            del mydict[original_sender]
-            return_content = "You've successfully quit the game."
-        else:
-            return_content = "Hmm, I didn't understand your input. Type **@tictactoe help** or **@ttt help** to see valid inputs."
+                return_content = "Hmm, I didn't understand your input. Type **@tictactoe help** or **@ttt help** to see valid inputs."
 
-        if "Game over" in return_content or "draw" in return_content:
-            del mydict[original_sender]
-
-        state_handler.set_state(mydict)
+            if "Game over" in return_content or "draw" in return_content:
+                del mydict[original_sender]
 
         bot_handler.send_message(dict(
             type = 'private',

--- a/zulip_bots/zulip_bots/bots/virtual_fs/virtual_fs.py
+++ b/zulip_bots/zulip_bots/bots/virtual_fs/virtual_fs.py
@@ -11,26 +11,23 @@ class VirtualFsHandler(object):
         command = message['content']
         if command == "":
             command = "help"
-        sender = message['sender_email']
 
-        state = state_handler.get_state()
-        if state is None:
-            state = {}
+        sender = message['sender_email']
 
         recipient = message['display_recipient']
         if isinstance(recipient, list):  # If not a stream, then hash on list of emails
             recipient = " ".join([x['email'] for x in recipient])
 
-        if recipient not in state:
-            state[recipient] = fs_new()
-        fs = state[recipient]
-        if sender not in fs['user_paths']:
-            fs['user_paths'][sender] = '/'
-        fs, msg = fs_command(fs, sender, command)
-        prependix = '{}:\n'.format(sender)
-        msg = prependix + msg
-        state[recipient] = fs
-        state_handler.set_state(state)
+        with state_handler.state({}) as state:
+            if recipient not in state:
+                state[recipient] = fs_new()
+            fs = state[recipient]
+            if sender not in fs['user_paths']:
+                fs['user_paths'][sender] = '/'
+            fs, msg = fs_command(fs, sender, command)
+            prependix = '{}:\n'.format(sender)
+            msg = prependix + msg
+            state[recipient] = fs
 
         bot_handler.send_reply(message, msg)
 

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -9,6 +9,8 @@ import re
 
 from six.moves import configparser
 
+from contextlib import contextmanager
+
 if False:
     from mypy_extensions import NoReturn
 from typing import Any, Optional, List, Dict
@@ -107,15 +109,22 @@ class ExternalBotHandler(object):
 class StateHandler(object):
     def __init__(self):
         # type: () -> None
-        self.state = None  # type: Any
+        self.state_ = None  # type: Any
 
     def set_state(self, state):
         # type: (Any) -> None
-        self.state = state
+        self.state_ = state
 
     def get_state(self):
         # type: () -> Any
-        return self.state
+        return self.state_
+
+    @contextmanager
+    def state(self, default):
+        #type: (Any) -> Any
+        new_state = self.get_state() or default
+        yield new_state
+        self.set_state(new_state)
 
 def run_message_handler_for_bot(lib_module, quiet, config_file):
     # type: (Any, bool, str) -> Any


### PR DESCRIPTION
**[This is a port of zulip/zulip#5671 from the main zulip repo]**

This PR simplifies the use of state-handling (following a suggestion in zulip/zulip#5653) and looks pretty clean to me, after having adjusted the existing stateful bots.

The default (initial value) parameter is relevant to all bots, so seemed fairly useful to include. Not all the stateful bot commits need be included, but at least two (virtual_fs and tictactoe) simply get state at the start and set it at the end, which makes it equivalent by my understanding.

As per the commit message for the lib commit, this is an additional feature, so the existing functions can still be used; equally the contextmanager can be used to identify prior state or 'flush' state manually within the 'with' block.

Does this approach seem reasonable @timabbott? (since it was your comment motivating this)