### PR TITLE
[WIP] Stateful bots: improve test coverage.

### DIFF
--- a/zulip_bots/zulip_bots/bots/incrementor/test_incrementor.py
+++ b/zulip_bots/zulip_bots/bots/incrementor/test_incrementor.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from zulip_bots.test_lib import BotTestCase
+from zulip_bots.lib import StateHandler
+
+
+class TestIncrementorBot(BotTestCase):
+    bot_name = "incrementor"
+
+    def test_bot(self):
+        messages = [  # Template for message inputs to test, absent of message content
+            {
+                'type': 'stream',
+                'display_recipient': 'some stream',
+                'subject': 'some subject',
+                'sender_email': 'foo_sender@zulip.com',
+            },
+            {
+                'type': 'private',
+                'sender_email': 'foo_sender@zulip.com',
+            },
+        ]
+        state_handler = StateHandler()
+        self.assert_bot_response(dict(messages[0], content=""), {'content': "1"},
+                                 'send_reply', state_handler)
+#        self.assert_bot_response(dict(messages[0], content=""), {'message_id': 5, 'content': "2"},
+#                                 'update_message', state_handler)

--- a/zulip_bots/zulip_bots/bots/tictactoe/test_tictactoe.py
+++ b/zulip_bots/zulip_bots/bots/tictactoe/test_tictactoe.py
@@ -28,17 +28,65 @@ class TestTictactoeBot(BotTestCase):
             'subject': 'foo_sender@zulip.com',  # FIXME Requiring this in bot is a bug?
         }
 
-        help_txt = "*Help for Tic-Tac-Toe bot* \nThe bot responds to messages starting with @mention-bot.\n**@mention-bot new** will start a new game (but not if you're already in the middle of a game). You must type this first to start playing!\n**@mention-bot help** will return this help function.\n**@mention-bot quit** will quit from the current game.\n**@mention-bot <coordinate>** will make a move at the given coordinate.\nCoordinates are entered in a (row, column) format. Numbering is from top to bottom and left to right. \nHere are the coordinates of each position. (Parentheses and spaces are optional). \n(1, 1)  (1, 2)  (1, 3) \n(2, 1)  (2, 2)  (2, 3) \n(3, 1) (3, 2) (3, 3) \n"
-        didnt_understand_txt = "Hmm, I didn't understand your input. Type **@tictactoe help** or **@ttt help** to see valid inputs."
-        new_game_txt = "Welcome to tic-tac-toe! You'll be x's and I'll be o's. Your move first!\nCoordinates are entered in a (row, column) format. Numbering is from top to bottom and left to right.\nHere are the coordinates of each position. (Parentheses and spaces are optional.) \n(1, 1)  (1, 2)  (1, 3) \n(2, 1)  (2, 2)  (2, 3) \n(3, 1) (3, 2) (3, 3) \n Your move would be one of these. To make a move, type @mention-bot followed by a space and the coordinate."
+        msg = dict(
+            help = "*Help for Tic-Tac-Toe bot* \nThe bot responds to messages starting with @mention-bot.\n**@mention-bot new** will start a new game (but not if you're already in the middle of a game). You must type this first to start playing!\n**@mention-bot help** will return this help function.\n**@mention-bot quit** will quit from the current game.\n**@mention-bot <coordinate>** will make a move at the given coordinate.\nCoordinates are entered in a (row, column) format. Numbering is from top to bottom and left to right. \nHere are the coordinates of each position. (Parentheses and spaces are optional). \n(1, 1)  (1, 2)  (1, 3) \n(2, 1)  (2, 2)  (2, 3) \n(3, 1) (3, 2) (3, 3) \n",
+            didnt_understand = "Hmm, I didn't understand your input. Type **@tictactoe help** or **@ttt help** to see valid inputs.",
+            new_game = "Welcome to tic-tac-toe! You'll be x's and I'll be o's. Your move first!\nCoordinates are entered in a (row, column) format. Numbering is from top to bottom and left to right.\nHere are the coordinates of each position. (Parentheses and spaces are optional.) \n(1, 1)  (1, 2)  (1, 3) \n(2, 1)  (2, 2)  (2, 3) \n(3, 1) (3, 2) (3, 3) \n Your move would be one of these. To make a move, type @mention-bot followed by a space and the coordinate.",
+            already_playing = "You're already playing a game! Type **@tictactoe help** or **@ttt help** to see valid inputs.",
+            already_played_there = 'That space is already filled, sorry!',
+            successful_quit = "You've successfully quit the game.",
+            after_1_1 = ("[ x _ _ ]\n[ _ _ _ ]\n[ _ _ _ ]\n"
+                         "My turn:\n[ x _ _ ]\n[ _ o _ ]\n[ _ _ _ ]\n"
+                         "Your turn! Enter a coordinate or type help."),
+            after_2_1 = ("[ x _ _ ]\n[ x o _ ]\n[ _ _ _ ]\n"
+                         "My turn:\n[ x _ _ ]\n[ x o _ ]\n[ o _ _ ]\n"
+                         "Your turn! Enter a coordinate or type help."),
+            after_1_3 = ("[ x _ x ]\n[ x o _ ]\n[ o _ _ ]\n"
+                         "My turn:\n[ x o x ]\n[ x o _ ]\n[ o _ _ ]\n"
+                         "Your turn! Enter a coordinate or type help."),
+            after_3_2 = ("[ x o x ]\n[ x o _ ]\n[ o x _ ]\n"
+                         "My turn:\n[ x o x ]\n[ x o o ]\n[ o x _ ]\n"
+                         "Your turn! Enter a coordinate or type help."),
+        )
 
         expected_send_message = [
-            ("", didnt_understand_txt),
-            ("help", help_txt),
-            ("quit", didnt_understand_txt),  # Quit not understood when no game
-            ("new", new_game_txt),
-            ("quit", "You've successfully quit the game."),  # If have state
-            ("quit", didnt_understand_txt),  # Quit not understood when no game
+            # Empty message
+            ("", msg['didnt_understand']),
+            # Non-command
+            ("adboh", msg['didnt_understand']),
+            # Help command
+            ("help", msg['help']),
+            # Command: quit not understood with no game
+            ("quit", msg['didnt_understand']),
+            # Can quit if new game and have state
+            ("new", msg['new_game']),
+            ("quit", msg['successful_quit']),
+            # Quit not understood when no game FIXME improve response?
+            ("quit", msg['didnt_understand']),
+            # New right after new just restarts
+            ("new", msg['new_game']),
+            ("new", msg['new_game']),
+            # Make a corner play
+            ("(1,1)", msg['after_1_1']),
+            # New while playing doesn't just restart
+            ("new", msg['already_playing']),
+            # User played in this location already
+            ("(1,1)", msg['already_played_there']),
+            # ... and bot played here
+            ("(2,2)", msg['already_played_there']),
+            ("quit", msg['successful_quit']),
+            # Can't play without game FIXME improve response?
+            ("(1,1)", msg['didnt_understand']),
+            ("new", msg['new_game']),
+            # Value out of range FIXME improve response?
+            ("(1,5)", msg['didnt_understand']),
+            # Value out of range FIXME improve response?
+            ("0,1", msg['didnt_understand']),
+            # Sequence of moves to show valid input formats:
+            ("1,1", msg['after_1_1']),
+            ("2, 1", msg['after_2_1']),
+            ("(1,3)", msg['after_1_3']),
+            # Can't test 'after_3_2' as it's random!
         ]
         for m in messages:
             state = StateHandler()

--- a/zulip_bots/zulip_bots/bots/virtual_fs/test_virtual_fs.py
+++ b/zulip_bots/zulip_bots/bots/virtual_fs/test_virtual_fs.py
@@ -4,45 +4,46 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 from zulip_bots.test_lib import BotTestCase
+from zulip_bots.lib import StateHandler
 
 class TestVirtualFsBot(BotTestCase):
     bot_name = "virtual_fs"
 
     def test_bot(self):
+        help_txt = ('foo_sender@zulip.com:\n\nThis bot implements a virtual file system for a stream.\n'
+                    'The locations of text are persisted for the lifetime of the bot\n'
+                    'running, and if you rename a stream, you will lose the info.\n'
+                    'Example commands:\n\n```\n'
+                    '@mention-bot sample_conversation: sample conversation with the bot\n'
+                    '@mention-bot mkdir: create a directory\n'
+                    '@mention-bot ls: list a directory\n'
+                    '@mention-bot cd: change directory\n'
+                    '@mention-bot pwd: show current path\n'
+                    '@mention-bot write: write text\n'
+                    '@mention-bot read: read text\n'
+                    '@mention-bot rm: remove a file\n'
+                    '@mention-bot rmdir: remove a directory\n'
+                    '```\n'
+                    'Use commands like `@mention-bot help write` for more details on specific\ncommands.\n')
         expected = {
             "cd /home": "foo_sender@zulip.com:\nERROR: invalid path",
             "mkdir home": "foo_sender@zulip.com:\ndirectory created",
             "pwd": "foo_sender@zulip.com:\n/",
-            "help": ('foo_sender@zulip.com:\n\nThis bot implements a virtual file system for a stream.\n'
-                     'The locations of text are persisted for the lifetime of the bot\n'
-                     'running, and if you rename a stream, you will lose the info.\n'
-                     'Example commands:\n\n```\n'
-                     '@mention-bot sample_conversation: sample conversation with the bot\n'
-                     '@mention-bot mkdir: create a directory\n'
-                     '@mention-bot ls: list a directory\n'
-                     '@mention-bot cd: change directory\n'
-                     '@mention-bot pwd: show current path\n'
-                     '@mention-bot write: write text\n'
-                     '@mention-bot read: read text\n'
-                     '@mention-bot rm: remove a file\n'
-                     '@mention-bot rmdir: remove a directory\n'
-                     '```\n'
-                     'Use commands like `@mention-bot help write` for more details on specific\ncommands.\n'),
+            "help": help_txt,
             "help ls": "foo_sender@zulip.com:\nsyntax: ls <optional_path>",
-            "": ('foo_sender@zulip.com:\n\nThis bot implements a virtual file system for a stream.\n'
-                 'The locations of text are persisted for the lifetime of the bot\n'
-                 'running, and if you rename a stream, you will lose the info.\n'
-                 'Example commands:\n\n```\n'
-                 '@mention-bot sample_conversation: sample conversation with the bot\n'
-                 '@mention-bot mkdir: create a directory\n'
-                 '@mention-bot ls: list a directory\n'
-                 '@mention-bot cd: change directory\n'
-                 '@mention-bot pwd: show current path\n'
-                 '@mention-bot write: write text\n'
-                 '@mention-bot read: read text\n'
-                 '@mention-bot rm: remove a file\n'
-                 '@mention-bot rmdir: remove a directory\n'
-                 '```\n'
-                 'Use commands like `@mention-bot help write` for more details on specific\ncommands.\n'),
+            "": help_txt,
         }
         self.check_expected_responses(expected)
+
+        expected = [
+            ("help", help_txt),
+            ("help ls", "foo_sender@zulip.com:\nsyntax: ls <optional_path>"),
+            ("", help_txt),
+            ("pwd", "foo_sender@zulip.com:\n/"),
+            ("cd /home", "foo_sender@zulip.com:\nERROR: invalid path"),
+            ("mkdir home", "foo_sender@zulip.com:\ndirectory created"),
+            ("cd /home", "foo_sender@zulip.com:\nCurrent path: /home/"),
+        ]
+
+        state_handler = StateHandler()
+        self.check_expected_responses(expected, state_handler = state_handler)


### PR DESCRIPTION
**Current state**:
* Awaiting confirmation that changes to bot testing lib are good, and whether to switch to list[tuple]
* TicTacToe tests should be good
* VirtualFS tests are a preliminary change pending ordered changes, unless just using a loop like in tictactoe; further other work pending discussion on whether 'sample conversation' should be re-used between bot and tests, or just copied.
* Incrementor test is highly minimal pending adding update_message testing being possible, likely in another branch, perhaps after multi-response #40?