### PR TITLE
python-zulip-api: Upgrade package versions (0.3.1 -> 0.3.2).

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -41,7 +41,7 @@ import logging
 import six
 from typing import Any, Callable, Dict, Iterable, IO, List, Mapping, Optional, Text, Tuple, Union
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 logger = logging.getLogger(__name__)
 

--- a/zulip_bots/setup.py
+++ b/zulip_bots/setup.py
@@ -8,7 +8,7 @@ import sys
 # We should be installable with either setuptools or distutils.
 package_info = dict(
     name='zulip_bots',
-    version='0.3.1',
+    version='0.3.2',
     description='Zulip\'s Bot framework',
     author='Zulip Open Source Project',
     author_email='zulip-devel@googlegroups.com',

--- a/zulip_botserver/setup.py
+++ b/zulip_botserver/setup.py
@@ -8,7 +8,7 @@ import sys
 # We should be installable with either setuptools or distutils.
 package_info = dict(
     name='zulip_botserver',
-    version='0.3.1',
+    version='0.3.2',
     description='Zulip\'s Flask server for running bots',
     author='Zulip Open Source Project',
     author_email='zulip-devel@googlegroups.com',


### PR DESCRIPTION
I just released all three of our pip packages:
* [zulip API bindings package](https://pypi.python.org/pypi/zulip)
* [zulip bots/bots API pakcage](https://pypi.python.org/pypi/zulip-bots)
* [zulip Flask bot server package](https://pypi.python.org/pypi/zulip-botserver)

I tested all three on my system and everything seems fine for now. The `zulip_bots` package doesn't ship fixtures or tests (like it shouldn't). I would really appreciate it if someone could test all three out in a virtualenv and give me some feedback! Thanks! :simple_smile: 