### PR TITLE
log2zulip: Fix to work on Python 3.

### DIFF
--- a/zulip/integrations/log2zulip/log2zulip
+++ b/zulip/integrations/log2zulip/log2zulip
@@ -88,7 +88,7 @@ def process_logs():
             # a log file ends up at the same line length as before
             # immediately after rotation, this tool won't notice.
             file_data["last"] = 1
-        new_lines = subprocess.check_output(["tail", "-n+%s" % (file_data["last"],), log_file]).split('\n')[:-1]
+        new_lines = subprocess.check_output(["tail", "-n+%s" % (file_data["last"],), log_file]).decode('utf-8', errors='replace').split('\n')[:-1]
         if len(new_lines) > 0:
             process_lines(new_lines, filename)
             file_data["last"] += len(new_lines)


### PR DESCRIPTION
I'm not thrilled with the `replace` error handler losing information
if the logfile contains invalid UTF-8 for some reason; but that sure
beats a UnicodeDecodeError, and for this script I can't quite be
bothered to run the rather tricky riddle trail that Python 3 makes it
to pass arbitrary byte data through layers of ordinary text processing.
