### PR TITLE
Bots: support run-time bot identity (improve eg. help commands) 

### DIFF
--- a/zulip_bots/zulip_bots/bots/wikipedia/test_wikipedia.py
+++ b/zulip_bots/zulip_bots/bots/wikipedia/test_wikipedia.py
@@ -56,7 +56,7 @@ class TestWikipediaBot(BotTestCase):
             )
 
         # Empty query, no request made to the Internet.
-        bot_response = "Please enter your message after @mention-bot"
+        bot_response = "Please enter your message after @**test bot**"
         self.assert_bot_response(
             message = {'content': ''},
             response = {'content': bot_response},

--- a/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
+++ b/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
@@ -37,10 +37,11 @@ class WikipediaHandler(object):
         bot_handler.send_reply(message, bot_response)
 
     def get_bot_wiki_response(self, message, bot_handler):
-        help_text = 'Please enter your message after @mention-bot'
+        help_text = 'Please enter your message after @{}'
         query = message['content']
         if query == '':
-            return help_text
+            quoted_name = bot_handler.identity().quoted_name
+            return help_text.format(quoted_name)
         query_wiki_link = ('https://en.wikipedia.org/w/api.php?action=query&'
                            'list=search&srsearch=%s&format=json'
                            % (urllib.parse.quote(query),))

--- a/zulip_bots/zulip_bots/bots/xkcd/test_xkcd.py
+++ b/zulip_bots/zulip_bots/bots/xkcd/test_xkcd.py
@@ -6,19 +6,22 @@ from __future__ import print_function
 import mock
 from mock import MagicMock, patch
 from zulip_bots.test_lib import BotTestCase
+from zulip_bots.lib import ExternalBotHandler
 
 class TestXkcdBot(BotTestCase):
     bot_name = "xkcd"
+    bot_identity = ExternalBotHandler.BotIdentity(name="xkcd bot", quoted_name="**xkcd bot**", email=None)
 
     @mock.patch('logging.exception')
     def test_bot(self, mock_logging_exception):
         help_txt = "xkcd bot supports these commands:"
         err_txt  = "xkcd bot only supports these commands, not `{}`:"
         commands = '''
-* `@xkcd help` to show this help message.
-* `@xkcd latest` to fetch the latest comic strip from xkcd.
-* `@xkcd random` to fetch a random comic strip from xkcd.
-* `@xkcd <comic id>` to fetch a comic strip based on `<comic id>` e.g `@xkcd 1234`.'''
+* `{0} help` to show this help message.
+* `{0} latest` to fetch the latest comic strip from xkcd.
+* `{0} random` to fetch a random comic strip from xkcd.
+* `{0} <comic id>` to fetch a comic strip based on `<comic id>` e.g `{0} 1234`.'''.format(
+            "@" + self.bot_identity.quoted_name)
         invalid_id_txt = "Sorry, there is likely no xkcd comic strip with id: #"
 
         # 'latest' query

--- a/zulip_bots/zulip_bots/bots/xkcd/xkcd.py
+++ b/zulip_bots/zulip_bots/bots/xkcd/xkcd.py
@@ -33,7 +33,8 @@ class XkcdHandler(object):
             '''
 
     def handle_message(self, message, bot_handler):
-        xkcd_bot_response = get_xkcd_bot_response(message)
+        quoted_name = bot_handler.identity().quoted_name
+        xkcd_bot_response = get_xkcd_bot_response(message, quoted_name)
         bot_handler.send_reply(message, xkcd_bot_response)
 
 class XkcdBotCommand(object):
@@ -47,16 +48,16 @@ class XkcdNotFoundError(Exception):
 class XkcdServerError(Exception):
     pass
 
-def get_xkcd_bot_response(message):
+def get_xkcd_bot_response(message, quoted_name):
     original_content = message['content'].strip()
     command = original_content.strip()
 
     commands_help = ("%s"
-                     "\n* `@xkcd help` to show this help message."
-                     "\n* `@xkcd latest` to fetch the latest comic strip from xkcd."
-                     "\n* `@xkcd random` to fetch a random comic strip from xkcd."
-                     "\n* `@xkcd <comic id>` to fetch a comic strip based on `<comic id>` "
-                     "e.g `@xkcd 1234`.")
+                     "\n* `@{0} help` to show this help message."
+                     "\n* `@{0} latest` to fetch the latest comic strip from xkcd."
+                     "\n* `@{0} random` to fetch a random comic strip from xkcd."
+                     "\n* `@{0} <comic id>` to fetch a comic strip based on `<comic id>` "
+                     "e.g `@{0} 1234`.".format(quoted_name))
 
     try:
         if command == 'help':

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -12,9 +12,11 @@ from six.moves import configparser
 
 from contextlib import contextmanager
 
+from collections import namedtuple
+
 if False:
     from mypy_extensions import NoReturn
-from typing import Any, Optional, List, Dict, IO, Text
+from typing import Any, Optional, List, Dict, IO, Text, NamedTuple
 from types import ModuleType
 
 from zulip import Client
@@ -88,6 +90,15 @@ class ExternalBotHandler(object):
             logging.error('Cannot fetch user profile, make sure you have set'
                           ' up the zuliprc file correctly.')
             sys.exit(1)
+
+    BotIdentity = namedtuple('BotIdentity', ['name', 'quoted_name', 'email'])
+
+    def identity(self):
+        # type: () -> NamedTuple
+        pad = '**' if ' ' in self.full_name else ''
+        return BotIdentity(self.full_name,
+                           "{0}{1}{0}".format(pad, self.full_name),
+                           self.email)
 
     def send_message(self, message):
         # type: (Dict[str, Any]) -> Dict[str, Any]

--- a/zulip_bots/zulip_bots/zulip_bot_output.py
+++ b/zulip_bots/zulip_bots/zulip_bot_output.py
@@ -83,6 +83,8 @@ def main():
         mock_bot_handler.update_message = MagicMock()
         if hasattr(message_handler, 'initialize') and callable(message_handler.initialize):
             message_handler.initialize(mock_bot_handler)
+        mock_bot_handler.identity = MagicMock()
+        mock_bot_handler.identity.return_value = ExternalBotHandler.BotIdentity("bot id", "**bot id**", None)
         message_handler.handle_message(
             message=message,
             bot_handler=mock_bot_handler


### PR DESCRIPTION
This improves the ability of a bot to specify how to mention it, which varies at run-time depending upon the identity used to run it; this is commonly used in many bot help commands.

The wikipedia and xkcd bots are ported as examples.

A similar approach to `mock_config_info` is used to mock the bot identity in a tests, which are also ported for these two bots.

I've wanted to have bots be able to give more contextual examples and this goes another step towards that. I'm also particularly open to thoughts on:
* how bot/user names are quoted (`user` vs `**user with space**`?)
* would a `quoted_name` method be more useful? (with or without the stars)
* if name/email is reasonable (it was available internally already); only name is currently used/tested