### PR TITLE
bots: Add complete test coverage for yoda bot.

### DIFF
--- a/zulip_bots/zulip_bots/bots/yoda/fixtures/test_invalid_input.json
+++ b/zulip_bots/zulip_bots/bots/yoda/fixtures/test_invalid_input.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "api_url": "https://yoda.p.mashape.com/yoda?sentence=@#$%^&*",
+    "headers": {
+      "X-Mashape-Key": "12345678",
+      "Accept": "text/plain"
+    }
+  },
+  "response": {"text": ""},
+  "response-headers": {
+    "status": 200,
+    "content-type": "text/html; charset=utf-8"
+  }
+}

--- a/zulip_bots/zulip_bots/bots/yoda/test_yoda.py
+++ b/zulip_bots/zulip_bots/bots/yoda/test_yoda.py
@@ -12,6 +12,7 @@ class TestYodaBot(BotTestCase):
 
     def test_bot(self):
 
+        # Test normal sentence (1).
         bot_response = "Learn how to speak like me someday, you will. Yes, hmmm."
 
         with self.mock_config_info({'api_key': '12345678'}), \
@@ -23,6 +24,7 @@ class TestYodaBot(BotTestCase):
                 expected_method='send_reply'
             )
 
+        # Test normal sentence (2).
         bot_response = "Much to learn, you still have."
 
         with self.mock_config_info({'api_key': '12345678'}), \
@@ -34,6 +36,7 @@ class TestYodaBot(BotTestCase):
                 expected_method='send_reply'
             )
 
+        # Test only numbers.
         bot_response = "23456.  Herh herh herh."
 
         with self.mock_config_info({'api_key': '12345678'}), \
@@ -45,6 +48,7 @@ class TestYodaBot(BotTestCase):
                 expected_method='send_reply'
             )
 
+        # Test help.
         bot_response = '''
             This bot allows users to translate a sentence into
             'Yoda speak'.
@@ -62,3 +66,33 @@ class TestYodaBot(BotTestCase):
             response = {'content': bot_response},
             expected_method='send_reply'
         )
+
+        # Test empty message.
+        bot_response = '''
+            This bot allows users to translate a sentence into
+            'Yoda speak'.
+            Users should preface messages with '@mention-bot'.
+
+            Before running this, make sure to get a Mashape Api token.
+            Instructions are in the 'readme.md' file.
+            Store it in the 'yoda.config' file.
+            The 'yoda.config' file should be located at '~/yoda.config'.
+            Example input:
+            @mention-bot You will learn how to speak like me someday.
+            '''
+        self.assert_bot_response(
+            message = {'content': ''},
+            response = {'content': bot_response},
+            expected_method='send_reply'
+        )
+
+        # Test invalid input.
+        bot_response = "Invalid input, please check the sentence you have entered."
+        with self.mock_config_info({'api_key': '12345678'}), \
+                self.mock_http_conversation('test_invalid_input'):
+            self.initialize_bot()
+            self.assert_bot_response(
+                message = {'content': '@#$%^&*'},
+                response = {'content': bot_response},
+                expected_method='send_reply'
+            )

--- a/zulip_bots/zulip_bots/bots/yoda/yoda.py
+++ b/zulip_bots/zulip_bots/bots/yoda/yoda.py
@@ -91,13 +91,17 @@ class YodaSpeakHandler(object):
     def handle_input(self, message, bot_handler):
 
         original_content = message['content']
-        if self.is_help(original_content):
+
+        if self.is_help(original_content) or (original_content == ""):
             bot_handler.send_reply(message, HELP_MESSAGE)
 
         else:
             sentence = self.format_input(original_content)
             try:
                 reply_message = self.send_to_yoda_api(sentence)
+
+                if len(reply_message) == 0:
+                    reply_message = 'Invalid input, please check the sentence you have entered.'
 
             except ssl.SSLError or TypeError:
                 reply_message = 'The service is temporarily unavailable, please try again.'


### PR DESCRIPTION
Add error handling support for empty messages and invalid
input to yoda bot, which was previously making the bot crash.
Add comments to describe tests.

This is as a followup for #53. I wasn't sure where to put the check for invalid input as the bot code was not responding to invalid input of special characters. Initially, I thought of putting a check by regular expressions (re.match)  but on further exploration, I found out that it is indeed sending an empty reply which is not handled properly by the code.