### PR TITLE
Handle empty messages in bot framework by default

### DIFF
--- a/zulip_bots/README.md
+++ b/zulip_bots/README.md
@@ -107,9 +107,11 @@ Each bot library simply needs to do the following:
 
 - Define a class that supports the methods `usage`
 and `handle_message`.
+- Optionally add a class member `ACCEPT_EMPTY_MESSAGES`, to
+specify that empty messages will be passed to the bot.
 - Set `handler_class` to be the name of that class.
 
-(We make this a two-step process to reduce code repetition
+(We make this a three-step process to reduce code repetition
 and to add abstraction.)
 
 ## Portability

--- a/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
+++ b/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
@@ -18,6 +18,8 @@ class WikipediaHandler(object):
     kind of external issue tracker as well.
     '''
 
+    ACCEPT_EMPTY_MESSAGES = 1
+
     def usage(self):
         return '''
             This plugin will allow users to directly search

--- a/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
+++ b/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
@@ -18,7 +18,10 @@ class WikipediaHandler(object):
     kind of external issue tracker as well.
     '''
 
-    ACCEPT_EMPTY_MESSAGES = 1
+    META = {'name': 'Wikipedia',
+            'description': 'Searches Wikipedia for a term and returns the top article.',
+            'no_defaults': True,  # Let bot handle all messages
+    }
 
     def usage(self):
         return '''

--- a/zulip_bots/zulip_bots/bots/xkcd/xkcd.py
+++ b/zulip_bots/zulip_bots/bots/xkcd/xkcd.py
@@ -6,6 +6,8 @@ import requests
 XKCD_TEMPLATE_URL = 'https://xkcd.com/%s/info.0.json'
 LATEST_XKCD_URL = 'https://xkcd.com/info.0.json'
 
+from collections import OrderedDict
+
 class XkcdHandler(object):
     '''
     This plugin provides several commands that can be used for fetch a comic
@@ -13,6 +15,16 @@ class XkcdHandler(object):
     "@mention-bot" and responds with a message with the comic based on provided
     commands.
     '''
+
+    META = {'name': 'XKCD',
+            'description': 'Fetches comic strips from https://xkcd.com.',
+            'no_defaults': False,
+            'commands': OrderedDict([
+                ('latest', "Show the latest comic strip"),
+                ('random', "Show a random comic strip"),
+                ('<comic id>', "Show a comic strip with a specific 'comic id'"),
+            ])
+    }
 
     def usage(self):
         return '''


### PR DESCRIPTION
This aims to implement #55.

These commits:
* Modify `lib.py` to intercept empty messages, if the bot class does not explicitly define `ACCEPT_EMPTY_MESSAGES` (and evaluates to `True`)
* Amend a local doc to mention this optional element of bot classes
* Amend the wikipedia bot, as a trial bot.

Outstanding points regarding this level of implementation:
* Other than the wikipedia bot, all other bots respond to empty messages via `lib.py`, since they've not all been updated.
* All the tests pass! This is since the tests just test the bot code, and so aren't aware of this interception.
* Is this document the accurate bot document? What about `docs/bot-guide.md` in the main repo?
* Is `ACCEPT_EMPTY_MESSAGES` a typical name/format to use in this case?