### PR TITLE
flaskserver: Load json python 3 compatible.

### DIFF
--- a/zulip_botserver/zulip_botserver/server.py
+++ b/zulip_botserver/zulip_botserver/server.py
@@ -73,7 +73,7 @@ def handle_bot(bot):
     # TODO: Handle stateful bots properly.
     state_handler = StateHandler()
 
-    event = json.loads(request.data)
+    event = request.get_json(force=True)
     message_handler.handle_message(message=event["message"],
                                    bot_handler=restricted_client,
                                    state_handler=state_handler)


### PR DESCRIPTION
`json.loads()` expects unicode text in python 3, but request.data is a raw bytestring, so this failed for python 3. Switching to flasks `get_json` method, with `force=True` so that the MIME type gets ignored and the behavior is the same as before.