### PR TITLE
travis: Test against Python 3.4, 3.5, and 3.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 install:
   - pip install pycodestyle==2.3.1
   - pip install ./zulip


### PR DESCRIPTION
Fixes #44.

When running Travis on this in my fork, there weren't any errors, and the build for all 4 python versions went reasonably fast (~90 seconds per version): https://travis-ci.org/derAnfaenger/python-zulip-api/builds/265157077