### PR TITLE
travis: Move linter to a separate job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+matrix:
+  include:
+  - python: "3.6"
+    env: TEST_SUITE=linter
 install:
   - pip install pycodestyle==2.3.1
   - pip install ./zulip
   - pip install ./zulip_bots
   - pip install ./zulip_botserver
 script:
-  - tools/lint
-  - python -m unittest discover -v zulip_botserver
-  - tools/test-bots
+  - tools/travis_tests

--- a/tools/server_lib/README.md
+++ b/tools/server_lib/README.md
@@ -1,6 +1,7 @@
 # Server Lib
 
-This directory contains file copied as is from the [zulip server repository](https://github.com/zulip/zulip) as they were on the commit `343cb20d570a8f5c1f5b6e6842058b294a376593`.
+This directory contains file copied as is from the [zulip server repository](https://github.com/zulip/zulip)
+as they were on the commit `343cb20d570a8f5c1f5b6e6842058b294a376593`.
 
 ## List of copied files
 

--- a/tools/travis_tests
+++ b/tools/travis_tests
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -ev
+
+CURRENT_DIR=$(dirname "$0")
+cd "$CURRENT_DIR"
+cd ..
+
+if [ "$TEST_SUITE" == "linter" ]
+then
+    tools/lint
+else
+    python -m unittest discover -v zulip_botserver
+    tools/test-bots
+fi


### PR DESCRIPTION
This moves the `tools/lint` command to a new Travis job. 
I tested this on my repo, both with a [build where the linter should fail](https://travis-ci.org/derAnfaenger/python-zulip-api/builds/265557352), and a [build where it should pass](https://travis-ci.org/derAnfaenger/python-zulip-api/builds/265557955): 

A second commit fixes a small issue the litner complains about. 