### PR TITLE
testing: Add build and coverage badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Zulip API
 
+![Build status](https://travis-ci.org/zulip/python-zulip-api.svg?branch=master)
+[![Coverage status](https://img.shields.io/codecov/c/github/zulip/python-zulip-api/master.svg)](
+https://codecov.io/gh/zulip/python-zulip-api)
+
 This repository contains the source code for Zulip's PyPI packages:
 
 * `zulip`: [PyPI package](https://pypi.python.org/pypi/zulip/)


### PR DESCRIPTION
Note the difference between this README.md and the zulip repo's one: Here, the coverage status badge is directly obtained from codecov, whereas in zulip, it's fetched from img.shields.io. This is why this badge says "codecov", whereas zulip's badge says "coverage".