### PR TITLE
api: Remove unnecessary API key details.

### DIFF
--- a/zulip/examples/create-user
+++ b/zulip/examples/create-user
@@ -29,7 +29,9 @@ usage = """create-user --new-email=<email address> --new-password=<password> --n
 Create a user. You must be a realm admin to use this API, and the user
 will be created in your realm.
 
-Example: create-user --site=http://localhost:9991 --user=rwbarton@example.com --new-email=jarthur@example.com --new-password=random17 --new-full-name 'J. Arthur Random' --new-short-name='jarthur'
+Example: create-user --new-email=jarthur@example.com --new-password=random17 --new-full-name 'J. Arthur Random' --new-short-name='jarthur'
+
+Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
 """
 
 import zulip

--- a/zulip/examples/edit-message
+++ b/zulip/examples/edit-message
@@ -24,13 +24,13 @@
 from __future__ import print_function
 import argparse
 
-usage = """edit-message [options] --message=<msg_id> --subject=<new subject> --content=<new content> --user=<sender's email address> --api-key=<sender's api key>
+usage = """edit-message [options] --message=<msg_id> --subject=<new subject> --content=<new content>
 
 Edits a message that you sent
 
-Example: edit-message --message-id="348135" --subject="my subject" --content="test message" --user=othello-bot@example.com --api-key=a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
+Example: edit-message --message-id="348135" --subject="my subject" --content="test message"
 
-You can omit --user and --api-key arguments if you have a properly set up ~/.zuliprc
+Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
 """
 
 import zulip

--- a/zulip/examples/get-public-streams
+++ b/zulip/examples/get-public-streams
@@ -24,13 +24,13 @@
 from __future__ import print_function
 import argparse
 
-usage = """get-public-streams --user=<bot's email address> --api-key=<bot's api key> [options]
+usage = """get-public-streams [options]
 
 Prints out all the public streams in the realm.
 
-Example: get-public-streams --user=othello-bot@example.com --api-key=a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
+Example: get-public-streams
 
-You can omit --user and --api-key arguments if you have a properly set up ~/.zuliprc
+Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
 """
 
 import zulip

--- a/zulip/examples/list-members
+++ b/zulip/examples/list-members
@@ -24,11 +24,13 @@
 from __future__ import print_function
 import argparse
 
-usage = """list-members --user=<bot's email address> --api-key=<bot's api key> [options]
+usage = """list-members [options]
 
 List the names and e-mail addresses of the people in your realm.
 
-You can omit --user and --api-key arguments if you have a properly set up ~/.zuliprc
+Example: list-members
+
+Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
 """
 
 import zulip

--- a/zulip/examples/list-subscriptions
+++ b/zulip/examples/list-subscriptions
@@ -24,13 +24,13 @@
 from __future__ import print_function
 import argparse
 
-usage = """list-subscriptions --user=<bot's email address> --api-key=<bot's api key> [options]
+usage = """list-subscriptions [options]
 
 Prints out a list of the user's subscriptions.
 
-Example: list-subscriptions --user=username@example.com --api-key=a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
+Example: list-subscriptions
 
-You can omit --user and --api-key arguments if you have a properly set up ~/.zuliprc
+Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
 """
 
 import zulip

--- a/zulip/examples/print-events
+++ b/zulip/examples/print-events
@@ -26,13 +26,13 @@ import argparse
 
 from typing import Any, Dict
 
-usage = """print-events --user=<bot's email address> --api-key=<bot's api key> [options]
+usage = """print-events [options]
 
 Prints out certain events received by the indicated bot or user matching the filter below.
 
-Example: print-events --user=username@example.com --api-key=a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
+Example: print-events
 
-You can omit --user and --api-key arguments if you have a properly set up ~/.zuliprc
+Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
 """
 
 import zulip

--- a/zulip/examples/print-messages
+++ b/zulip/examples/print-messages
@@ -26,13 +26,13 @@ import argparse
 
 from typing import Any, Dict
 
-usage = """print-messages --user=<bot's email address> --api-key=<bot's api key> [options]
+usage = """print-messages [options]
 
 Prints out each message received by the indicated bot or user.
 
-Example: print-messages --user=username@example.com --api-key=a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
+Example: print-messages
 
-You can omit --user and --api-key arguments if you have a properly set up ~/.zuliprc
+Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
 """
 
 import zulip

--- a/zulip/examples/recent-messages
+++ b/zulip/examples/recent-messages
@@ -25,13 +25,13 @@ from __future__ import print_function
 import json
 import argparse
 
-usage = """recent-messages [options] --count=<no. of previous messages> --user=<sender's email address> --api-key=<sender's api key>
+usage = """recent-messages [options] --count=<no. of previous messages>
 
-Prints out last count messages received by the indicated bot or user
+Prints out last count messages received by the bot or user used for authentication.
 
-Example: recent-messages --count=101 --user=username@example.com --api-key=a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
+Example: recent-messages --count=101
 
-You can omit --user and --api-key arguments if you have a properly set up ~/.zuliprc
+Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
 """
 
 import zulip

--- a/zulip/examples/subscribe
+++ b/zulip/examples/subscribe
@@ -25,14 +25,14 @@ from __future__ import print_function
 import sys
 import argparse
 
-usage = """subscribe --user=<bot's email address> --api-key=<bot's api key> [options] --streams=<streams>
+usage = """subscribe [options] --streams=<streams>
 
 Ensures the user is subscribed to the listed streams.
 
-Examples: subscribe --user=username@example.com --api-key=a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5 --streams=foo
-          subscribe --user=username@example.com --api-key=a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5 --streams='foo bar'
+Examples: subscribe --streams=foo
+          subscribe --streams='foo bar'
 
-You can omit --user and --api-key arguments if you have a properly set up ~/.zuliprc
+Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
 """
 
 import zulip

--- a/zulip/examples/unsubscribe
+++ b/zulip/examples/unsubscribe
@@ -25,14 +25,14 @@ from __future__ import print_function
 import sys
 import argparse
 
-usage = """unsubscribe  --user=<bot's email address> --api-key=<bot's api key> [options] --streams=<streams>
+usage = """unsubscribe [options] --streams=<streams>
 
 Ensures the user is not subscribed to the listed streams.
 
-Examples: unsubscribe --user=username@example.com --api-key=a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5 --streams=foo
-          unsubscribe --user=username@example.com --api-key=a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5 --streams='foo bar'
+Examples: unsubscribe --streams=foo
+          unsubscribe --streams='foo bar'
 
-You can omit --user and --api-key arguments if you have a properly set up ~/.zuliprc
+Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
 """
 
 import zulip

--- a/zulip/examples/upload-file
+++ b/zulip/examples/upload-file
@@ -31,13 +31,13 @@ import zulip
 class StringIO(_StringIO):
     name = ''  # https://github.com/python/typeshed/issues/598
 
-usage = """upload-file --user=<user's email address> --api-key=<user's api key> [options]
+usage = """upload-file [options]
 
 Upload a file, and print the corresponding URI.
 
-Example: upload-file --user=cordelia@zulip.com --api-key=a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5 --file-path=cat.png
+Example: upload-file --file-path=cat.png
 
-You can omit --user and --api-key arguments if you have a properly set up ~/.zuliprc
+Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
 If no --file-path is specified, a placeholder text file will be used instead.
 """
 

--- a/zulip/integrations/google/google-calendar
+++ b/zulip/integrations/google/google-calendar
@@ -42,11 +42,11 @@ sys.path.append(os.path.dirname(__file__))
 
 parser = zulip.add_default_arguments(argparse.ArgumentParser(r"""
 
-google-calendar \
-    --user foo@zulip.com \
-    --calendar calendarID@example.calendar.google.com
+google-calendar --calendar calendarID@example.calendar.google.com
 
     This integration can be used to send yourself reminders, on Zulip, of Google Calendar Events.
+
+    Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
 
     Before running this integration make sure you run the get-google-credentials file to give Zulip
     access to certain aspects of your Google Account.

--- a/zulip/integrations/irc/irc-mirror.py
+++ b/zulip/integrations/irc/irc-mirror.py
@@ -106,13 +106,13 @@ class IRCBot(irc.bot.SingleServerIRCBot):
                 return
             self.dcc_connect(address, port)
 
-usage = """./irc-mirror.py --server=IRC_SERVER --channel=<CHANNEL> --nick-prefix=<NICK> [optional args]
+usage = """./irc-mirror.py --irc-server=IRC_SERVER --channel=<CHANNEL> --nick-prefix=<NICK> [optional args]
 
 Example:
 
 ./irc-mirror.py --irc-server=127.0.0.1 --channel='#test' --nick-prefix=username
-  --site=https://zulip.example.com --user=irc-bot@example.com
-  --api-key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
 
 Note that "_zulip" will be automatically appended to the IRC nick provided
 

--- a/zulip/zulip/send.py
+++ b/zulip/zulip/send.py
@@ -60,8 +60,7 @@ def main():
     Examples: zulip-send --stream denmark --subject castle -m "Something is rotten in the state of Denmark."
               zulip-send hamlet@example.com cordelia@example.com -m "Conscience doth make cowards of us all."
 
-    These examples assume you have a proper '~/.zuliprc'. You may also set your credentials with the
-    '--user' and '--api-key' arguments.
+    Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
     """
 
     parser = zulip.add_default_arguments(argparse.ArgumentParser(usage=usage))


### PR DESCRIPTION
Fixes #1.

For `create-user` and `google-calendar`, the examples did not specify a --api-key argument - I have assumed this to be a mistake and proceeded by removing the single `--user` options, along with adding the note for the requirement of a `.zuliprc` file.

The twitter bot man is fixed in #89.