### PR TITLE
api: Ensure automatic tilde expansion.

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -246,6 +246,9 @@ class Client(object):
         if client is None:
             client = _default_client()
 
+        # Normalize user-specified path
+        if config_file is not None:
+            config_file = os.path.abspath(os.path.expanduser(config_file))
         # Fill values from Environment Variables if not available in Constructor
         if config_file is None:
             config_file = os.environ.get("ZULIP_CONFIG")
@@ -293,7 +296,7 @@ class Client(object):
                     raise RuntimeError("insecure is set to '%s', it must be 'true' or 'false' if it is used in %s"
                                        % (insecure_setting, config_file))
         elif None in (api_key, email):
-            raise RuntimeError("api_key or email not specified and %s does not exist"
+            raise RuntimeError("api_key or email not specified and file %s does not exist"
                                % (config_file,))
 
         self.api_key = api_key

--- a/zulip_botserver/zulip_botserver/server.py
+++ b/zulip_botserver/zulip_botserver/server.py
@@ -20,6 +20,9 @@ bots_lib_module = {}  # type: Dict[str, Any]
 
 def read_config_file(config_file_path):
     # type: (str) -> None
+    config_file_path = os.path.abspath(os.path.expanduser(config_file_path))
+    if not os.path.isfile(config_file_path):
+        raise IOError("Could not read config file {}: File not found.".format(config_file_path))
     parser = SafeConfigParser()
     parser.read(config_file_path)
 
@@ -55,7 +58,8 @@ def handle_bot(bot):
     lib_module = get_bot_lib_module(bot)
     if lib_module is None:
         return BadRequest("Can't find the configuration or Bot Handler code for bot {}. "
-                          "Make sure that the `zulip_bots` package is installed!".format(bot))
+                          "Make sure that the `zulip_bots` package is installed, and "
+                          "that your flaskbotrc is set up correctly".format(bot))
 
     client = Client(email=bots_config[bot]["email"],
                     api_key=bots_config[bot]["key"],


### PR DESCRIPTION
When working in vagrant with the zulip botserver, I faced a subtle bug: specifying `--config-file ~/flaskbotrc` did *not* automatically expand the tilde (I don't know why, though). Since it does not get expanded by `os.path.abspath` and other functions, the file coud not be found. The same problem occurs in any terminal when putting the argument in quotes (`--config-file "~/flaskbotrc"`).

This commit:
* automatically expands any tilde with `os.path.expanduser` in the `Client` object and for the botserver.
* prints a comprehensible warning when the specified config file is not found in the botserver (until now, only a BadRequest was being thrown, leading to a `400` error message)