### PR TITLE
Refactor zulip_bots scripts.

### DIFF
--- a/zulip_bots/zulip_bots/run.py
+++ b/zulip_bots/zulip_bots/run.py
@@ -76,9 +76,9 @@ def parse_args():
     parser.add_argument('--provision',
                         action='store_true',
                         help='Install dependencies for the bot.')
-    options = parser.parse_args()
+    args = parser.parse_args()
 
-    if not options.name and not options.path_to_bot:
+    if not args.name and not args.path_to_bot:
         error_message = """
 You must either specify the name of an existing bot or
 specify a path to the file (--path-to-bot) that contains
@@ -89,40 +89,40 @@ the bot handler class.
     # checks if both of these are in sync, otherwise we'll
     # have to be bias towards one and the user may get incorrect
     # result.
-    elif not name_and_path_match(options.name, options.path_to_bot):
+    elif not name_and_path_match(args.name, args.path_to_bot):
         error_message = """
 Please make sure that the given name of the bot and the
 given path to the bot are same and valid.
 """
         parser.error(error_message)
 
-    return options
+    return args
 
 
 def main():
     # type: () -> None
-    options = parse_args()
-    bot_name = options.name
-    if options.path_to_bot:
-        if options.provision:
-            bot_dir = os.path.dirname(os.path.abspath(options.path_to_bot))
-            provision_bot(bot_dir, options.force)
-        lib_module = import_module_from_source(options.path_to_bot, name=bot_name)
-    elif options.name:
-        if options.provision:
+    args = parse_args()
+    bot_name = args.name
+    if args.path_to_bot:
+        if args.provision:
+            bot_dir = os.path.dirname(os.path.abspath(args.path_to_bot))
+            provision_bot(bot_dir, args.force)
+        lib_module = import_module_from_source(args.path_to_bot, name=bot_name)
+    elif args.name:
+        if args.provision:
             current_dir = os.path.dirname(os.path.abspath(__file__))
             bots_parent_dir = os.path.join(current_dir, "bots")
-            bot_dir = os.path.join(bots_parent_dir, options.name)
-            provision_bot(bot_dir, options.force)
+            bot_dir = os.path.join(bots_parent_dir, args.name)
+            provision_bot(bot_dir, args.force)
         lib_module = import_module('zulip_bots.bots.{bot}.{bot}'.format(bot=bot_name))
 
-    if not options.quiet:
+    if not args.quiet:
         logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
     run_message_handler_for_bot(
         lib_module=lib_module,
-        config_file=options.config_file,
-        quiet=options.quiet,
+        config_file=args.config_file,
+        quiet=args.quiet,
         bot_name=bot_name
     )
 

--- a/zulip_bots/zulip_bots/run.py
+++ b/zulip_bots/zulip_bots/run.py
@@ -59,7 +59,7 @@ def parse_args():
 
     parser.add_argument('--quiet', '-q',
                         action='store_true',
-                        help='Turn off logging output.')
+                        help='turn off logging output')
 
     parser.add_argument('--config-file',
                         action='store',
@@ -71,11 +71,11 @@ def parse_args():
 
     parser.add_argument('--force',
                         action='store_true',
-                        help='Try running the bot even if dependencies install fails.')
+                        help='try running the bot even if dependencies install fails')
 
     parser.add_argument('--provision',
                         action='store_true',
-                        help='Install dependencies for the bot.')
+                        help='install dependencies for the bot')
     args = parser.parse_args()
 
     if not args.name and not args.path_to_bot:

--- a/zulip_bots/zulip_bots/zulip_bot_output.py
+++ b/zulip_bots/zulip_bots/zulip_bot_output.py
@@ -51,9 +51,9 @@ def parse_args():
                         action='store_true',
                         help='Install dependencies for the bot.')
 
-    options = parser.parse_args()
+    args = parser.parse_args()
 
-    if not options.name and not options.path_to_bot:
+    if not args.name and not args.path_to_bot:
         error_message = """
 You must either specify the name of an existing bot or
 specify a path to the file (--path-to-bot) that contains
@@ -64,33 +64,33 @@ the bot handler class.
     # checks if both of these are in sync, otherwise we'll
     # have to be bias towards one and the user may get incorrect
     # result.
-    elif not name_and_patch_match(options.name, options.path_to_bot):
+    elif not name_and_patch_match(args.name, args.path_to_bot):
         error_message = """
 Please make sure that the given name of the bot and the
 given path to the bot are same and valid.
 """
         parser.error(error_message)
 
-    return options
+    return args
 
 def main():
     # type: () -> None
-    options = parse_args()
-    bot_name = options.name
-    if options.path_to_bot:
-        if options.provision:
-            bot_dir = os.path.dirname(os.path.abspath(options.path_to_bot))
-            provision_bot(bot_dir, options.force)
-        lib_module = import_module_from_source(options.path_to_bot, name=bot_name)
-    elif options.name:
-        if options.provision:
+    args = parse_args()
+    bot_name = args.name
+    if args.path_to_bot:
+        if args.provision:
+            bot_dir = os.path.dirname(os.path.abspath(args.path_to_bot))
+            provision_bot(bot_dir, args.force)
+        lib_module = import_module_from_source(args.path_to_bot, name=bot_name)
+    elif args.name:
+        if args.provision:
             current_dir = os.path.dirname(os.path.abspath(__file__))
             bots_parent_dir = os.path.join(current_dir, "bots")
-            bot_dir = os.path.join(bots_parent_dir, options.name)
-            provision_bot(bot_dir, options.force)
+            bot_dir = os.path.join(bots_parent_dir, args.name)
+            provision_bot(bot_dir, args.force)
         lib_module = import_module('zulip_bots.bots.{bot}.{bot}'.format(bot=bot_name))
 
-    message = {'content': options.message, 'sender_email': 'foo_sender@zulip.com'}
+    message = {'content': args.message, 'sender_email': 'foo_sender@zulip.com'}
     message_handler = lib_module.handler_class()
 
     with patch('zulip_bots.lib.ExternalBotHandler') as mock_bot_handler:
@@ -120,7 +120,7 @@ def main():
             bot_handler=mock_bot_handler,
             state_handler=StateHandler()
         )
-        print("On sending ", options.name, " bot the following message:\n\"", options.message, "\"")
+        print("On sending ", args.name, " bot the following message:\n\"", args.message, "\"")
 
         # send_reply and send_message have slightly arguments; the
         # following takes that into account.

--- a/zulip_bots/zulip_bots/zulip_bot_output.py
+++ b/zulip_bots/zulip_bots/zulip_bot_output.py
@@ -2,21 +2,18 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
-import argparse
-import sys
 import os
-from types import ModuleType
-from importlib import import_module
-from os.path import basename, splitext
+import sys
+import argparse
+import zulip_bots
 
-import six
 from six.moves import configparser
-import mock
-from mock import MagicMock, patch
 
-from zulip_bots.lib import run_message_handler_for_bot, StateHandler
+from mock import MagicMock, patch
+from zulip_bots.lib import StateHandler
+from zulip_bots.lib import ExternalBotHandler
 from zulip_bots.provision import provision_bot
-from zulip_bots.run import import_module_from_source, name_and_patch_match
+from zulip_bots.run import import_module_from_source
 
 def parse_args():
     usage = '''

--- a/zulip_bots/zulip_bots/zulip_bot_output.py
+++ b/zulip_bots/zulip_bots/zulip_bot_output.py
@@ -77,18 +77,23 @@ def main():
             bot_handler=mock_bot_handler,
             state_handler=StateHandler()
         )
-        print("On sending ", bot_name, " bot the following message:\n\"", args.message, "\"")
-
+        print("On sending {} bot the message \"{}\"".format(bot_name, args.message))
         # send_reply and send_message have slightly arguments; the
         # following takes that into account.
         #   send_reply(original_message, response)
         #   send_message(response_message)
         if mock_bot_handler.send_reply.called:
-            print("\nThe bot gives the following output message:\n\"", list(mock_bot_handler.send_reply.call_args)[0][1], "\"")
+            output_message = list(mock_bot_handler.send_reply.call_args)[0][1]
         elif mock_bot_handler.send_message.called:
-            print("\nThe bot sends the following output to zulip:\n\"", list(mock_bot_handler.send_message.call_args)[0][0], "\"")
+            output_message = list(mock_bot_handler.send_message.call_args)[0][0]
+        elif mock_bot_handler.update_message.called:
+            output_message = list(mock_bot_handler.update_message.call_args)[0][0]['content']
+            print("the bot updates a message with the following text (in quotes):\n\"{}\"".format(output_message))
+            sys.exit()
         else:
-            print("\nThe bot sent no reply.")
+            print("the bot sent no reply.")
+            sys.exit()
+        print("the bot gives the following output message (in quotes):\n\"{}\"".format(output_message))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Originally, this was intended to refactor the zulip_bot_output.py script. While working on it, I found parallels to run.py and a little inconsistency in lib.py.

Concerning followups on zulip_bot_output:
* I cannot create a symlink as we need it on Windows, someone else would have to do that.
* I'll work on the documentation tomorrow.