### PR TITLE
zulip setup.py: Remove redundant directory forward slash.

### DIFF
--- a/zulip/setup.py
+++ b/zulip/setup.py
@@ -55,7 +55,7 @@ package_info = dict(
                   "examples/send-message",
                   "examples/subscribe",
                   "examples/unsubscribe",
-                  ])] + list(recur_expand('share/zulip', 'integrations/')),
+                  ])] + list(recur_expand('share/zulip', 'integrations')),
     entry_points={
         'console_scripts': [
             'zulip-send=zulip.send:main',


### PR DESCRIPTION
The slash caused pip install ./zulip to fail on Windows with
Python 3.5.
This is the complete traceback:
```
  Running setup.py install for zulip: started
    Running setup.py install for zulip: finished with status 'error'
    Complete output from command c:\users\robert\appdata\local\programs\python\python35-32\python.exe -u -c "import setuptools, tokenize;__file__='C:\\Users\\Robert\\AppData\\Local\\Temp\\pip-roerrrzu-build\\setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record C:\Users\Robert\AppData\Local\Temp\pip-q33jxzeb-record\install-record.txt --single-version-externally-managed --compile:
    running install_data
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\Robert\AppData\Local\Temp\pip-roerrrzu-build\setup.py", line 98, in <module>
        setup(**package_info)
      File "c:\users\robert\appdata\local\programs\python\python35-32\lib\distutils\core.py", line 148, in setup
        dist.run_commands()
      File "c:\users\robert\appdata\local\programs\python\python35-32\lib\distutils\dist.py", line 955, in run_commands
        self.run_command(cmd)
      File "c:\users\robert\appdata\local\programs\python\python35-32\lib\distutils\dist.py", line 974, in run_command
        cmd_obj.run()
      File "c:\users\robert\appdata\local\programs\python\python35-32\lib\distutils\command\install_data.py", line 56, in run
        dir = convert_path(f[0])
      File "c:\users\robert\appdata\local\programs\python\python35-32\lib\distutils\util.py", line 127, in convert_path
        raise ValueError("path '%s' cannot end with '/'" % pathname)
    ValueError: path 'share/zulip\integrations/' cannot end with '/'
```