### PR TITLE
travis: Install codecodv in the correct place.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ matrix:
   - python: "3.6"
     env: TEST_SUITE=lint
 install:
-  - pip install codecov
   - tools/provision
   - source zulip-api-py*-venv/bin/activate
 script:
   - tools/$TEST_SUITE
 after_success:
+  - pip install codecov
   - codecov


### PR DESCRIPTION
Before this commit, codecov got installed for each test job,
but was only needed *after* all jobs had passed: in after_success.
This lead to codecov silently failing, as it was not installed when
it was actually needed.