### PR TITLE
zulip_bots: Add unittests for run.py.

### DIFF
--- a/zulip_bots/zulip_bots/run.py
+++ b/zulip_bots/zulip_bots/run.py
@@ -10,8 +10,6 @@ from types import ModuleType
 from importlib import import_module
 from os.path import basename, splitext
 
-import six
-
 from zulip_bots.lib import run_message_handler_for_bot
 from zulip_bots.provision import provision_bot
 
@@ -21,7 +19,9 @@ def import_module_from_source(path, name=None):
     if not name:
         name = splitext(basename(path))[0]
 
-    if six.PY2:
+    # importlib.util.module_from_spec is supported from Python3.5
+    py_version = sys.version_info
+    if py_version.major < 3 or (py_version.major == 3 and py_version.minor < 5):
         import imp
         module = imp.load_source(name, path)
     else:

--- a/zulip_bots/zulip_bots/test_run.py
+++ b/zulip_bots/zulip_bots/test_run.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+
+import importlib
+import os
+import zulip_bots.run
+import six
+import unittest
+import zulip
+
+from importlib import import_module
+from unittest import TestCase
+
+if six.PY2:
+    import mock
+    from mock import patch
+else:
+    from unittest import mock
+    from unittest.mock import patch
+
+class TestDefaultArguments(TestCase):
+
+    our_dir = os.path.dirname(__file__)
+    path_to_bot = os.path.abspath(os.path.join(our_dir, 'bots/giphy/giphy.py'))
+
+    @patch('sys.argv', ['zulip-run-bot', 'giphy', '--config-file', '/foo/bar/baz.conf'])
+    @patch('zulip_bots.run.run_message_handler_for_bot')
+    def test_argument_parsing_with_bot_name(self, mock_run_message_handler_for_bot):
+        zulip_bots.run.main()
+        mock_run_message_handler_for_bot.assert_called_with(bot_name='giphy',
+                                                            config_file='/foo/bar/baz.conf',
+                                                            lib_module=mock.ANY,
+                                                            quiet=False)
+
+    @patch('sys.argv', ['zulip-run-bot', path_to_bot, '--config-file', '/foo/bar/baz.conf'])
+    @patch('zulip_bots.run.run_message_handler_for_bot')
+    def test_argument_parsing_with_bot_path(self, mock_run_message_handler_for_bot):
+        zulip_bots.run.main()
+        mock_run_message_handler_for_bot.assert_called_with(
+            bot_name='giphy',
+            config_file='/foo/bar/baz.conf',
+            lib_module=mock.ANY,
+            quiet=False)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
These are tests that assert the correct argument
parsing; the successful execution of bots is not verified.

Writing these tests made me aware of an import flake for Python 3.0 - 3.4; this is fixed by the first commit.