### PR TITLE
zulip package: Make check for provision failsafe.

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -228,7 +228,7 @@ def generate_option_group(parser, prefix=''):
 def init_from_options(options, client=None):
     # type: (Any, Optional[str]) -> Client
 
-    if options.provision:
+    if getattr(options, 'provision', False):
         requirements_path = os.path.abspath(os.path.join(sys.path[0], 'requirements.txt'))
         try:
             import pip


### PR DESCRIPTION
It is not guaranteed that the integration scripts in
the Zulip repository even specify a `provision` option.
Therefore, checking the value of this option would fail.
Updating this with getattr and a default value.

Fascinating how the added test suite immediately catches a bug.