### PR TITLE
codecov: Adjust failure threshold.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,6 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 0.03
+        threshold: 0.85
         base: auto
     patch: off


### PR DESCRIPTION
The previous threshold was taken over from the zulip repo,
which contains much more LOC. The new threshold reflects the
size of the `python-zulip-api` repo.

I made my calculations by running the command `git ls-files | grep -v .png | xargs cat | wc -l` on both repos, printing out the LOC.
Then, new_threshold = (zulip_LOC / python-zulip-api_LOC) * 0.03 ~= 0.85

zulip_LOC: 508196
python-zulip-api_LOC: 17905

I don't know if we have public figures similar to these, but I guess it'd be some impressive stats to mention (also for other repos).