### PR TITLE
provision: Give a better error message; ensure the correct version of pip.

### DIFF
--- a/tools/provision
+++ b/tools/provision
@@ -3,8 +3,6 @@
 import os
 import sys
 import argparse
-import pip
-import six
 import subprocess
 import warnings
 

--- a/tools/provision
+++ b/tools/provision
@@ -24,10 +24,18 @@ the Python version this command is executed with."""
 
     venv_dir = os.path.join(base_dir, venv_name)
     if not os.path.isdir(venv_dir):
-        if subprocess.call(['virtualenv', '-p', python_interpreter, venv_dir]):
-            raise OSError("The command `virtualenv -p {} {}` failed. Virtualenv not created!"
-                          .format(python_interpreter, venv_dir))
+        try:
+            return_code = subprocess.call(['virtualenv', '-p', python_interpreter, venv_dir])
+        except OSError:
+            if subprocess.call(['which', 'virtualenv']):
+                print("{red}Please install the virtualenv package and try again.{end_format}"
+                      .format(red='\033[91m', end_format='\033[0m'))
+                sys.exit(1)
+            raise
         else:
+            if return_code:
+                raise OSError("The command `virtualenv -p {} {}` failed. Virtualenv not created!"
+                              .format(python_interpreter, venv_dir))
             print("New virtualenv created.")
     else:
         print("Virtualenv already exists.")

--- a/tools/provision
+++ b/tools/provision
@@ -59,8 +59,10 @@ the Python version this command is executed with."""
     # the venv's Python interpreter. `--prefix venv_dir` ensures that all modules are installed
     # in the right place.
     def install_dependencies(requirements_filename):
-        if subprocess.call([os.path.join(venv_dir, venv_exec_dir, 'pip'),
-                           'install', '--prefix', venv_dir, '-r', os.path.join(base_dir, requirements_filename)]):
+        pip_path = os.path.join(venv_dir, venv_exec_dir, 'pip')
+        subprocess.call([pip_path, 'install', 'pip>=9.0'])
+        if subprocess.call([pip_path, 'install', '--prefix', venv_dir, '-r',
+                            os.path.join(base_dir, requirements_filename)]):
             raise OSError("The command `pip install -r {}` failed. Dependencies not installed!"
                           .format(os.path.join(base_dir, requirements_filename)))
 


### PR DESCRIPTION
Right now when the `virtualenv` package is not installed the related `subprocess` call results in an error with the following traceback:
```
Traceback (most recent call last):
  File "./tools/provision", line 68, in <module>
    main()
  File "./tools/provision", line 25, in main
    if subprocess.call(['virtualenv', '-p', python_interpreter, venv_dir]):
  File "/usr/lib/python2.7/subprocess.py", line 522, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```
I think it would be great to have a more beginner-friendly error message for this easy-to-fix (and potentially frequent) case.