### PR TITLE
bots: Mark --message/-m argument to zulip_bot_output.py as required.

### DIFF
--- a/zulip_bots/zulip_bots/zulip_bot_output.py
+++ b/zulip_bots/zulip_bots/zulip_bot_output.py
@@ -33,7 +33,7 @@ def parse_args():
                         action='store',
                         help='the name or path an existing bot to run')
 
-    parser.add_argument('--message', '-m',
+    parser.add_argument('--message', '-m', required=True,
                         action='store',
                         help='the message content to send to the bot')
 


### PR DESCRIPTION
A minor fix; `zulip_bot_output.py` does not check for presence of `--message`, so it should be marked as required to avoid a traceback.