### PR TITLE
bots: Further improvements to zulip_bot_output.py, beyond PR #130

### DIFF
--- a/zulip_bots/zulip_bots/zulip_bot_output.py
+++ b/zulip_bots/zulip_bots/zulip_bot_output.py
@@ -20,7 +20,8 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 def parse_args():
     description = (
         "A tool to test a bot: given a provided message, provides the bot response.\n\n"
-        'Example: %(prog)s xkcd "1"')
+        'Examples:   %(prog)s xkcd 1\n'
+        '            %(prog)s ./bot_folder/my_own_bot.py "test message"')
     epilog = (
         "The message need only be enclosed in quotes if empty or containing spaces.\n\n"
         "(Internally, this program loads bot-related code from the library code and\n"

--- a/zulip_bots/zulip_bots/zulip_bot_output.py
+++ b/zulip_bots/zulip_bots/zulip_bot_output.py
@@ -19,8 +19,8 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 
 def parse_args():
     usage = '''
-        zulip-bot-output <bot_name> --message "Send this message to the bot"
-        Example: zulip-bot-output xkcd --message "1"
+        zulip-bot-output <bot_name> <message>
+        Example: zulip-bot-output xkcd "1"
         This tool can be used for testing bots by sending simple messages
         and capturing the response.
         (Internally, this program loads bot-related code from the
@@ -33,8 +33,7 @@ def parse_args():
                         action='store',
                         help='the name or path an existing bot to run')
 
-    parser.add_argument('--message', '-m',
-                        required=True,
+    parser.add_argument('message',
                         action='store',
                         help='the message content to send to the bot')
 

--- a/zulip_bots/zulip_bots/zulip_bot_output.py
+++ b/zulip_bots/zulip_bots/zulip_bot_output.py
@@ -68,7 +68,11 @@ def main():
         sys.exit(1)
 
     message = {'content': args.message, 'sender_email': 'foo_sender@zulip.com'}
-    message_handler = lib_module.handler_class()
+    try:
+        message_handler = lib_module.handler_class()
+    except AttributeError:
+        print("This module does not appear to have a bot handler_class specified.")
+        sys.exit(1)
 
     with patch('zulip.Client') as mock_client:
         mock_bot_handler = ExternalBotHandler(mock_client, bot_dir)

--- a/zulip_bots/zulip_bots/zulip_bot_output.py
+++ b/zulip_bots/zulip_bots/zulip_bot_output.py
@@ -18,18 +18,17 @@ from zulip_bots.run import import_module_from_source
 current_dir = os.path.dirname(os.path.abspath(__file__))
 
 def parse_args():
-    usage = '''
-        zulip-bot-output <bot_name> <message>
-        Example: zulip-bot-output xkcd "1"
-        The message need only be enclosed in quotes if empty or containing spaces.
-        This tool can be used for testing bots by sending simple messages
-        and capturing the response.
-        (Internally, this program loads bot-related code from the
-        library code and then feeds the message provided
-        in the command to the library code to handle.)
-        '''
+    description = (
+        "A tool to test a bot: given a provided message, provides the bot response.\n\n"
+        'Example: %(prog)s xkcd "1"')
+    epilog = (
+        "The message need only be enclosed in quotes if empty or containing spaces.\n\n"
+        "(Internally, this program loads bot-related code from the library code and\n"
+        "then feeds the message provided in the command to the library code to handle.)")
 
-    parser = argparse.ArgumentParser(usage=usage)
+    parser = argparse.ArgumentParser(description=description,
+                                     epilog=epilog,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('bot',
                         action='store',
                         help='the name or path an existing bot to run')

--- a/zulip_bots/zulip_bots/zulip_bot_output.py
+++ b/zulip_bots/zulip_bots/zulip_bot_output.py
@@ -21,6 +21,7 @@ def parse_args():
     usage = '''
         zulip-bot-output <bot_name> <message>
         Example: zulip-bot-output xkcd "1"
+        The message need only be enclosed in quotes if empty or containing spaces.
         This tool can be used for testing bots by sending simple messages
         and capturing the response.
         (Internally, this program loads bot-related code from the

--- a/zulip_bots/zulip_bots/zulip_bot_output.py
+++ b/zulip_bots/zulip_bots/zulip_bot_output.py
@@ -61,7 +61,11 @@ def main():
     bot_dir = os.path.dirname(bot_path)
     if args.provision:
         provision_bot(os.path.dirname(bot_path), args.force)
-    lib_module = import_module_from_source(bot_path, bot_name)
+    try:
+        lib_module = import_module_from_source(bot_path, bot_name)
+    except IOError:
+        print("Could not find and import bot '{}'".format(bot_name))
+        sys.exit(1)
 
     message = {'content': args.message, 'sender_email': 'foo_sender@zulip.com'}
     message_handler = lib_module.handler_class()


### PR DESCRIPTION
* Move -m/--message to positional (as per discussion at end of #130)
* Add note regarding quoting messages being optional but necessary with spaces or empty
* Move to built-in argparse formatting (is this considered undesirable?)
* Adjusted examples to show use with/without quotes, and named vs path/to/bot
* Check for failed bot module import (ie. incorrect bot path usage)
* Check for provided module is a bot (ie. contains handler_class)

Re the last point, it suggests the idea of a 'bot_lint', which tests whether a module provides the bot API?