### PR TITLE
virtual_fs bot: Use EmbeddedBot state handler.

### DIFF
--- a/zulip_bots/zulip_bots/bots/commute/commute.py
+++ b/zulip_bots/zulip_bots/bots/commute/commute.py
@@ -180,7 +180,7 @@ class CommuteHandler(object):
         result = validate_requests(r)
         return result
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         original_content = message['content']
         query = original_content.split()
 

--- a/zulip_bots/zulip_bots/bots/converter/converter.py
+++ b/zulip_bots/zulip_bots/bots/converter/converter.py
@@ -46,7 +46,7 @@ class ConverterHandler(object):
                all supported units.
                '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         bot_response = get_bot_converter_response(message, bot_handler)
         bot_handler.send_reply(message, bot_response)
 

--- a/zulip_bots/zulip_bots/bots/converter/test_converter.py
+++ b/zulip_bots/zulip_bots/bots/converter/test_converter.py
@@ -9,14 +9,14 @@ class TestConverterBot(BotTestCase):
     bot_name = "converter"
 
     def test_bot(self):
-        expected = {
-            "": ('Too few arguments given. Enter `@convert help` '
+        expected = [
+            ("", 'Too few arguments given. Enter `@convert help` '
                  'for help on using the converter.\n'),
-            "foo bar": ('Too few arguments given. Enter `@convert help` '
+            ("foo bar", 'Too few arguments given. Enter `@convert help` '
                         'for help on using the converter.\n'),
-            "2 m cm": "2.0 m = 200.0 cm\n",
-            "12.0 celsius fahrenheit": "12.0 celsius = 53.600054 fahrenheit\n",
-            "0.002 kilometer millimile": "0.002 kilometer = 1.2427424 millimile\n",
-            "3 megabyte kilobit": "3.0 megabyte = 24576.0 kilobit\n",
-        }
+            ("2 m cm", "2.0 m = 200.0 cm\n"),
+            ("12.0 celsius fahrenheit", "12.0 celsius = 53.600054 fahrenheit\n"),
+            ("0.002 kilometer millimile", "0.002 kilometer = 1.2427424 millimile\n"),
+            ("3 megabyte kilobit", "3.0 megabyte = 24576.0 kilobit\n"),
+        ]
         self.check_expected_responses(expected)

--- a/zulip_bots/zulip_bots/bots/define/define.py
+++ b/zulip_bots/zulip_bots/bots/define/define.py
@@ -23,7 +23,7 @@ class DefineHandler(object):
             messages with @mention-bot.
             '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         original_content = message['content'].strip()
         bot_response = self.get_bot_define_response(original_content)
 

--- a/zulip_bots/zulip_bots/bots/encrypt/encrypt.py
+++ b/zulip_bots/zulip_bots/bots/encrypt/encrypt.py
@@ -28,7 +28,7 @@ class EncryptHandler(object):
             Feeding encrypted messages into the bot decrypts them.
             '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         bot_response = self.get_bot_encrypt_response(message)
         bot_handler.send_reply(message, bot_response)
 

--- a/zulip_bots/zulip_bots/bots/encrypt/test_encrypt.py
+++ b/zulip_bots/zulip_bots/bots/encrypt/test_encrypt.py
@@ -9,11 +9,11 @@ class TestEncryptBot(BotTestCase):
     bot_name = "encrypt"
 
     def test_bot(self):
-        expected = {
-            "": "Encrypted/Decrypted text: ",
-            "Let\'s Do It": "Encrypted/Decrypted text: Yrg\'f Qb Vg",
-            "me&mom together..!!": "Encrypted/Decrypted text: zr&zbz gbtrgure..!!",
-            "foo bar": "Encrypted/Decrypted text: sbb one",
-            "Please encrypt this": "Encrypted/Decrypted text: Cyrnfr rapelcg guvf",
-        }
+        expected = [
+            ("", "Encrypted/Decrypted text: "),
+            ("Let\'s Do It", "Encrypted/Decrypted text: Yrg\'f Qb Vg"),
+            ("me&mom together..!!", "Encrypted/Decrypted text: zr&zbz gbtrgure..!!"),
+            ("foo bar", "Encrypted/Decrypted text: sbb one"),
+            ("Please encrypt this", "Encrypted/Decrypted text: Cyrnfr rapelcg guvf"),
+        ]
         self.check_expected_responses(expected)

--- a/zulip_bots/zulip_bots/bots/followup/followup.py
+++ b/zulip_bots/zulip_bots/bots/followup/followup.py
@@ -22,7 +22,7 @@ class FollowupHandler(object):
             called "followup" that your API user can send to.
             '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         if message['content'] == '':
             bot_response = "Please specify the message you want to send to followup stream after @mention-bot"
             bot_handler.send_reply(message, bot_response)

--- a/zulip_bots/zulip_bots/bots/followup/test_followup.py
+++ b/zulip_bots/zulip_bots/bots/followup/test_followup.py
@@ -9,23 +9,21 @@ class TestFollowUpBot(BotTestCase):
     bot_name = "followup"
 
     def test_bot(self):
-        expected_send_reply = {
-            "": 'Please specify the message you want to send to followup stream after @mention-bot'
-        }
+        expected_send_reply = [
+            ("", 'Please specify the message you want to send to followup stream after @mention-bot')
+        ]
         self.check_expected_responses(expected_send_reply, expected_method='send_reply')
 
-        expected_send_message = {
-            "foo": {
-                'type': 'stream',
-                'to': 'followup',
-                'subject': 'foo_sender@zulip.com',
-                'content': 'from foo_sender@zulip.com: foo',
-            },
-            "I have completed my task": {
-                'type': 'stream',
-                'to': 'followup',
-                'subject': 'foo_sender@zulip.com',
-                'content': 'from foo_sender@zulip.com: I have completed my task',
-            },
-        }
+        expected_send_message = [
+            ("foo",
+             {'type': 'stream',
+              'to': 'followup',
+              'subject': 'foo_sender@zulip.com',
+              'content': 'from foo_sender@zulip.com: foo'}),
+            ("I have completed my task",
+             {'type': 'stream',
+              'to': 'followup',
+              'subject': 'foo_sender@zulip.com',
+              'content': 'from foo_sender@zulip.com: I have completed my task'}),
+        ]
         self.check_expected_responses(expected_send_message, expected_method='send_message')

--- a/zulip_bots/zulip_bots/bots/foursquare/foursquare.py
+++ b/zulip_bots/zulip_bots/bots/foursquare/foursquare.py
@@ -47,7 +47,7 @@ Example Inputs:
     def send_info(self, message, letter, bot_handler):
         bot_handler.send_reply(message, letter)
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         words = message['content'].split()
         if "/help" in words:
             self.send_info(message, self.help_info, bot_handler)

--- a/zulip_bots/zulip_bots/bots/giphy/giphy.py
+++ b/zulip_bots/zulip_bots/bots/giphy/giphy.py
@@ -31,7 +31,7 @@ class GiphyHandler(object):
         global config_info
         config_info = bot_handler.get_config_info('giphy')
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         bot_response = get_bot_giphy_response(message, bot_handler)
         bot_handler.send_reply(message, bot_response)
 

--- a/zulip_bots/zulip_bots/bots/git_hub_comment/git_hub_comment.py
+++ b/zulip_bots/zulip_bots/bots/git_hub_comment/git_hub_comment.py
@@ -39,7 +39,7 @@ class GitHubHandler(object):
             '<repository_owner>/<repository>/<issue_number>/<your_comment>'.
             '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         original_content = message['content']
         original_sender = message['sender_email']
 

--- a/zulip_bots/zulip_bots/bots/github_detail/github_detail.py
+++ b/zulip_bots/zulip_bots/bots/github_detail/github_detail.py
@@ -69,7 +69,7 @@ class GithubHandler(object):
                 repo = self.repo
         return (owner, repo)
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         # type: () -> None
         # Send help message
         if message['content'] == 'help':

--- a/zulip_bots/zulip_bots/bots/github_issues/github_issues.py
+++ b/zulip_bots/zulip_bots/bots/github_issues/github_issues.py
@@ -47,7 +47,7 @@ class IssueHandler(object):
             github_token = <oauth_token>   (The personal access token for the GitHub bot)
             '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
 
         original_content = message['content']
         original_sender = message['sender_email']

--- a/zulip_bots/zulip_bots/bots/googlesearch/googlesearch.py
+++ b/zulip_bots/zulip_bots/bots/googlesearch/googlesearch.py
@@ -72,7 +72,7 @@ class GoogleSearchHandler(object):
             @mentioned-bot.
             '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         original_content = message['content']
         result = get_google_result(original_content)
         bot_handler.send_reply(message, result)

--- a/zulip_bots/zulip_bots/bots/helloworld/helloworld.py
+++ b/zulip_bots/zulip_bots/bots/helloworld/helloworld.py
@@ -11,7 +11,7 @@ class HelloWorldHandler(object):
         sophisticated, bots.
         '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         content = 'beep boop'
         bot_handler.send_reply(message, content)
 

--- a/zulip_bots/zulip_bots/bots/helloworld/test_helloworld.py
+++ b/zulip_bots/zulip_bots/bots/helloworld/test_helloworld.py
@@ -13,4 +13,4 @@ class TestHelloWorldBot(BotTestCase):
     def test_bot(self):
         txt = "beep boop"
         messages = ["", "foo", "Hi, my name is abc"]
-        self.check_expected_responses(dict(list(zip(messages, len(messages)*[txt]))))
+        self.check_expected_responses(list(zip(messages, len(messages)*[txt])))

--- a/zulip_bots/zulip_bots/bots/help/help.py
+++ b/zulip_bots/zulip_bots/bots/help/help.py
@@ -11,7 +11,7 @@ class HelpHandler(object):
             your Zulip instance.
             '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         help_content = "Info on Zulip can be found here:\nhttps://github.com/zulip/zulip"
         bot_handler.send_reply(message, help_content)
 

--- a/zulip_bots/zulip_bots/bots/help/test_help.py
+++ b/zulip_bots/zulip_bots/bots/help/test_help.py
@@ -13,4 +13,4 @@ class TestHelpBot(BotTestCase):
     def test_bot(self):
         txt = "Info on Zulip can be found here:\nhttps://github.com/zulip/zulip"
         messages = ["", "help", "Hi, my name is abc"]
-        self.check_expected_responses(dict(list(zip(messages, len(messages)*[txt]))))
+        self.check_expected_responses(list(zip(messages, len(messages)*[txt])))

--- a/zulip_bots/zulip_bots/bots/howdoi/howdoi.py
+++ b/zulip_bots/zulip_bots/bots/howdoi/howdoi.py
@@ -81,7 +81,7 @@ class HowdoiHandler(object):
 
         return answer
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         question = message['content'].strip()
 
         if question.startswith('howdowe!'):

--- a/zulip_bots/zulip_bots/bots/incrementor/incrementor.py
+++ b/zulip_bots/zulip_bots/bots/incrementor/incrementor.py
@@ -12,7 +12,7 @@ class IncrementorHandler(object):
         '''
 
     def handle_message(self, message, bot_handler):
-        with bot_handler.state_handler.state({'number': 0, 'message_id': None}) as state:
+        with bot_handler.storage.state({'number': 0, 'message_id': None}) as state:
             state['number'] += 1
             if state['message_id'] is None:
                 result = bot_handler.send_reply(message, str(state['number']))

--- a/zulip_bots/zulip_bots/bots/incrementor/incrementor.py
+++ b/zulip_bots/zulip_bots/bots/incrementor/incrementor.py
@@ -11,8 +11,8 @@ class IncrementorHandler(object):
         is @-mentioned, this number will be incremented in the same message.
         '''
 
-    def handle_message(self, message, bot_handler, state_handler):
-        with state_handler.state({'number': 0, 'message_id': None}) as state:
+    def handle_message(self, message, bot_handler):
+        with bot_handler.state_handler.state({'number': 0, 'message_id': None}) as state:
             state['number'] += 1
             if state['message_id'] is None:
                 result = bot_handler.send_reply(message, str(state['number']))

--- a/zulip_bots/zulip_bots/bots/incrementor/incrementor.py
+++ b/zulip_bots/zulip_bots/bots/incrementor/incrementor.py
@@ -11,17 +11,24 @@ class IncrementorHandler(object):
         is @-mentioned, this number will be incremented in the same message.
         '''
 
+    def initialize(self, bot_handler):
+        storage = bot_handler.storage
+        if not storage.contains('number') or not storage.contains('message_id'):
+            storage.put('number', 0)
+            storage.put('message_id', None)
+
     def handle_message(self, message, bot_handler):
-        with bot_handler.storage.state({'number': 0, 'message_id': None}) as state:
-            state['number'] += 1
-            if state['message_id'] is None:
-                result = bot_handler.send_reply(message, str(state['number']))
-                state['message_id'] = result['id']
-            else:
-                bot_handler.update_message(dict(
-                    message_id = state['message_id'],
-                    content = str(state['number'])
-                ))
+        storage = bot_handler.storage
+        num = storage.get('number')
+        storage.put('number', num + 1)
+        if storage.get('message_id') is None:
+            result = bot_handler.send_reply(message, str(storage.get('number')))
+            storage.put('message_id', result['id'])
+        else:
+            bot_handler.update_message(dict(
+                message_id = storage.get('message_id'),
+                content = str(storage.get('number'))
+            ))
 
 
 handler_class = IncrementorHandler

--- a/zulip_bots/zulip_bots/bots/incrementor/test_incrementor.py
+++ b/zulip_bots/zulip_bots/bots/incrementor/test_incrementor.py
@@ -23,9 +23,8 @@ class TestIncrementorBot(BotTestCase):
                 'sender_email': 'foo_sender@zulip.com',
             },
         ]
-        storage = StateHandler()
         self.assert_bot_response(dict(messages[0], content=""), {'content': "1"},
-                                 'send_reply', storage)
+                                 'send_reply')
         # Last test commented out since we don't have update_message
         # support in the test framework yet.
 

--- a/zulip_bots/zulip_bots/bots/incrementor/test_incrementor.py
+++ b/zulip_bots/zulip_bots/bots/incrementor/test_incrementor.py
@@ -23,11 +23,11 @@ class TestIncrementorBot(BotTestCase):
                 'sender_email': 'foo_sender@zulip.com',
             },
         ]
-        state_handler = StateHandler()
+        storage = StateHandler()
         self.assert_bot_response(dict(messages[0], content=""), {'content': "1"},
-                                 'send_reply', state_handler)
+                                 'send_reply', storage)
         # Last test commented out since we don't have update_message
         # support in the test framework yet.
 
         # self.assert_bot_response(dict(messages[0], content=""), {'message_id': 5, 'content': "2"},
-        #                          'update_message', state_handler)
+        #                          'update_message', storage)

--- a/zulip_bots/zulip_bots/bots/incrementor/test_incrementor.py
+++ b/zulip_bots/zulip_bots/bots/incrementor/test_incrementor.py
@@ -11,6 +11,7 @@ class TestIncrementorBot(BotTestCase):
     bot_name = "incrementor"
 
     def test_bot(self):
+        self.initialize_bot()
         messages = [  # Template for message inputs to test, absent of message content
             {
                 'type': 'stream',

--- a/zulip_bots/zulip_bots/bots/john/john.py
+++ b/zulip_bots/zulip_bots/bots/john/john.py
@@ -103,7 +103,7 @@ class JohnHandler(object):
         )
         self.chatterbot = create_chat_bot(True)
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         original_content = message['content']
         bot_response = str(self.chatterbot.get_response(original_content))
         bot_handler.send_reply(message, bot_response)

--- a/zulip_bots/zulip_bots/bots/tictactoe/test_tictactoe.py
+++ b/zulip_bots/zulip_bots/bots/tictactoe/test_tictactoe.py
@@ -86,11 +86,11 @@ class TestTictactoeBot(BotTestCase):
             ("1,1", msg['after_1_1']),
             ("2, 1", msg['after_2_1']),
             ("(1,3)", msg['after_1_3']),
+            ("quit", msg['successful_quit']),
             # Can't test 'after_3_2' as it's random!
         ]
         for m in messages:
-            state = StateHandler()
             for (mesg, resp) in expected_send_message:
                 self.assert_bot_response(dict(m, content=mesg),
                                          dict(private_response, content=resp),
-                                         'send_message', state)
+                                         'send_message')

--- a/zulip_bots/zulip_bots/bots/tictactoe/tictactoe.py
+++ b/zulip_bots/zulip_bots/bots/tictactoe/tictactoe.py
@@ -282,10 +282,11 @@ class ticTacToeHandler(object):
         original_sender = message['sender_email']
 
         with bot_handler.storage.state({}) as mydict:
-            user_game = mydict.get(original_sender)
-            if (not user_game) and command == "new":
-                user_game = TicTacToeGame(copy.deepcopy(initial_board))
-                mydict[original_sender] = user_game
+            user_board = mydict.get(original_sender)
+            if (not user_board) and command == "new":
+                user_board = copy.deepcopy(initial_board)
+                mydict[original_sender] = user_board
+            user_game = TicTacToeGame(user_board) if user_board else None
 
             if command == 'new':
                 if user_game and not first_time(user_game.board):

--- a/zulip_bots/zulip_bots/bots/tictactoe/tictactoe.py
+++ b/zulip_bots/zulip_bots/bots/tictactoe/tictactoe.py
@@ -281,7 +281,7 @@ class ticTacToeHandler(object):
             command += val
         original_sender = message['sender_email']
 
-        with bot_handler.state_handler.state({}) as mydict:
+        with bot_handler.storage.state({}) as mydict:
             user_game = mydict.get(original_sender)
             if (not user_game) and command == "new":
                 user_game = TicTacToeGame(copy.deepcopy(initial_board))

--- a/zulip_bots/zulip_bots/bots/tictactoe/tictactoe.py
+++ b/zulip_bots/zulip_bots/bots/tictactoe/tictactoe.py
@@ -274,14 +274,14 @@ class ticTacToeHandler(object):
             message starts with @mention-bot.
             '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         command_list = message['content']
         command = ""
         for val in command_list:
             command += val
         original_sender = message['sender_email']
 
-        with state_handler.state({}) as mydict:
+        with bot_handler.state_handler.state({}) as mydict:
             user_game = mydict.get(original_sender)
             if (not user_game) and command == "new":
                 user_game = TicTacToeGame(copy.deepcopy(initial_board))

--- a/zulip_bots/zulip_bots/bots/virtual_fs/test_virtual_fs.py
+++ b/zulip_bots/zulip_bots/bots/virtual_fs/test_virtual_fs.py
@@ -8,42 +8,41 @@ from zulip_bots.lib import StateHandler
 
 class TestVirtualFsBot(BotTestCase):
     bot_name = "virtual_fs"
+    help_txt = ('foo_sender@zulip.com:\n\nThis bot implements a virtual file system for a stream.\n'
+                'The locations of text are persisted for the lifetime of the bot\n'
+                'running, and if you rename a stream, you will lose the info.\n'
+                'Example commands:\n\n```\n'
+                '@mention-bot sample_conversation: sample conversation with the bot\n'
+                '@mention-bot mkdir: create a directory\n'
+                '@mention-bot ls: list a directory\n'
+                '@mention-bot cd: change directory\n'
+                '@mention-bot pwd: show current path\n'
+                '@mention-bot write: write text\n'
+                '@mention-bot read: read text\n'
+                '@mention-bot rm: remove a file\n'
+                '@mention-bot rmdir: remove a directory\n'
+                '```\n'
+                'Use commands like `@mention-bot help write` for more details on specific\ncommands.\n')
 
-    def test_bot(self):
-        help_txt = ('foo_sender@zulip.com:\n\nThis bot implements a virtual file system for a stream.\n'
-                    'The locations of text are persisted for the lifetime of the bot\n'
-                    'running, and if you rename a stream, you will lose the info.\n'
-                    'Example commands:\n\n```\n'
-                    '@mention-bot sample_conversation: sample conversation with the bot\n'
-                    '@mention-bot mkdir: create a directory\n'
-                    '@mention-bot ls: list a directory\n'
-                    '@mention-bot cd: change directory\n'
-                    '@mention-bot pwd: show current path\n'
-                    '@mention-bot write: write text\n'
-                    '@mention-bot read: read text\n'
-                    '@mention-bot rm: remove a file\n'
-                    '@mention-bot rmdir: remove a directory\n'
-                    '```\n'
-                    'Use commands like `@mention-bot help write` for more details on specific\ncommands.\n')
-        expected = {
-            "cd /home": "foo_sender@zulip.com:\nERROR: invalid path",
-            "mkdir home": "foo_sender@zulip.com:\ndirectory created",
-            "pwd": "foo_sender@zulip.com:\n/",
-            "help": help_txt,
-            "help ls": "foo_sender@zulip.com:\nsyntax: ls <optional_path>",
-            "": help_txt,
-        }
+    def test_commands_1(self):
+        expected = [
+            ("cd /home", "foo_sender@zulip.com:\nERROR: invalid path"),
+            ("mkdir home", "foo_sender@zulip.com:\ndirectory created"),
+            ("pwd", "foo_sender@zulip.com:\n/"),
+            ("help", self.help_txt),
+            ("help ls", "foo_sender@zulip.com:\nsyntax: ls <optional_path>"),
+            ("", self.help_txt),
+        ]
         self.check_expected_responses(expected)
 
+    def test_commands_2(self):
         expected = [
-            ("help", help_txt),
+            ("help", self.help_txt),
             ("help ls", "foo_sender@zulip.com:\nsyntax: ls <optional_path>"),
-            ("", help_txt),
+            ("", self.help_txt),
             ("pwd", "foo_sender@zulip.com:\n/"),
             ("cd /home", "foo_sender@zulip.com:\nERROR: invalid path"),
             ("mkdir home", "foo_sender@zulip.com:\ndirectory created"),
             ("cd /home", "foo_sender@zulip.com:\nCurrent path: /home/"),
         ]
-
-        storage = StateHandler()
-        self.check_expected_responses(expected, storage = storage)
+        self.check_expected_responses(expected)

--- a/zulip_bots/zulip_bots/bots/virtual_fs/test_virtual_fs.py
+++ b/zulip_bots/zulip_bots/bots/virtual_fs/test_virtual_fs.py
@@ -45,5 +45,5 @@ class TestVirtualFsBot(BotTestCase):
             ("cd /home", "foo_sender@zulip.com:\nCurrent path: /home/"),
         ]
 
-        state_handler = StateHandler()
-        self.check_expected_responses(expected, state_handler = state_handler)
+        storage = StateHandler()
+        self.check_expected_responses(expected, storage = storage)

--- a/zulip_bots/zulip_bots/bots/virtual_fs/virtual_fs.py
+++ b/zulip_bots/zulip_bots/bots/virtual_fs/virtual_fs.py
@@ -18,7 +18,7 @@ class VirtualFsHandler(object):
         if isinstance(recipient, list):  # If not a stream, then hash on list of emails
             recipient = " ".join([x['email'] for x in recipient])
 
-        with bot_handler.state_handler.state({}) as state:
+        with bot_handler.storage.state({}) as state:
             if recipient not in state:
                 state[recipient] = fs_new()
             fs = state[recipient]

--- a/zulip_bots/zulip_bots/bots/virtual_fs/virtual_fs.py
+++ b/zulip_bots/zulip_bots/bots/virtual_fs/virtual_fs.py
@@ -18,16 +18,16 @@ class VirtualFsHandler(object):
         if isinstance(recipient, list):  # If not a stream, then hash on list of emails
             recipient = " ".join([x['email'] for x in recipient])
 
-        with bot_handler.storage.state({}) as state:
-            if recipient not in state:
-                state[recipient] = fs_new()
-            fs = state[recipient]
-            if sender not in fs['user_paths']:
-                fs['user_paths'][sender] = '/'
-            fs, msg = fs_command(fs, sender, command)
-            prependix = '{}:\n'.format(sender)
-            msg = prependix + msg
-            state[recipient] = fs
+        storage = bot_handler.storage
+        if not storage.contains(recipient):
+            storage.put(recipient, fs_new())
+        fs = storage.get(recipient)
+        if sender not in fs['user_paths']:
+            fs['user_paths'][sender] = '/'
+        fs, msg = fs_command(fs, sender, command)
+        prependix = '{}:\n'.format(sender)
+        msg = prependix + msg
+        storage.put(recipient, fs)
 
         bot_handler.send_reply(message, msg)
 

--- a/zulip_bots/zulip_bots/bots/virtual_fs/virtual_fs.py
+++ b/zulip_bots/zulip_bots/bots/virtual_fs/virtual_fs.py
@@ -7,7 +7,7 @@ class VirtualFsHandler(object):
     def usage(self):
         return get_help()
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         command = message['content']
         if command == "":
             command = "help"
@@ -18,7 +18,7 @@ class VirtualFsHandler(object):
         if isinstance(recipient, list):  # If not a stream, then hash on list of emails
             recipient = " ".join([x['email'] for x in recipient])
 
-        with state_handler.state({}) as state:
+        with bot_handler.state_handler.state({}) as state:
             if recipient not in state:
                 state[recipient] = fs_new()
             fs = state[recipient]

--- a/zulip_bots/zulip_bots/bots/weather/weather.py
+++ b/zulip_bots/zulip_bots/bots/weather/weather.py
@@ -13,7 +13,7 @@ class WeatherHandler(object):
             This plugin will give info about weather in a specified city
             '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         help_content = '''
             This bot returns weather info for specified city.
             You specify city in the following format:

--- a/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
+++ b/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
@@ -32,7 +32,7 @@ class WikipediaHandler(object):
             should preface searches with "@mention-bot".
             '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         bot_response = self.get_bot_wiki_response(message, bot_handler)
         bot_handler.send_reply(message, bot_response)
 

--- a/zulip_bots/zulip_bots/bots/xkcd/xkcd.py
+++ b/zulip_bots/zulip_bots/bots/xkcd/xkcd.py
@@ -32,7 +32,7 @@ class XkcdHandler(object):
             `<comic_id>`, e.g `@mention-bot 1234`.
             '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         xkcd_bot_response = get_xkcd_bot_response(message)
         bot_handler.send_reply(message, xkcd_bot_response)
 

--- a/zulip_bots/zulip_bots/bots/yoda/yoda.py
+++ b/zulip_bots/zulip_bots/bots/yoda/yoda.py
@@ -54,7 +54,7 @@ class YodaSpeakHandler(object):
             @mention-bot You will learn how to speak like me someday.
             '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         self.handle_input(message, bot_handler)
 
     def send_to_yoda_api(self, sentence):

--- a/zulip_bots/zulip_bots/bots/youtube/youtube.py
+++ b/zulip_bots/zulip_bots/bots/youtube/youtube.py
@@ -8,7 +8,7 @@ class YoutubeHandler(object):
             This bot will return the first Youtube search result for the give query.
             '''
 
-    def handle_message(self, message, bot_handler, state_handler):
+    def handle_message(self, message, bot_handler):
         help_content = '''
             To use the, Youtube Bot send `@mention-bot search terms`
             Example:

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import json
 import logging
 import os
 import signal
@@ -54,22 +55,21 @@ class RateLimit(object):
 class StateHandler(object):
     def __init__(self):
         # type: () -> None
-        self.state_ = None  # type: Any
+        self.state_ = {}  # type: Dict[Text, Text]
+        self.marshal = lambda obj: obj
+        self.demarshal = lambda obj: obj
 
-    def set_state(self, state):
-        # type: (Any) -> None
-        self.state_ = state
+    def put(self, key, value):
+        # type: (Text, Text) -> None
+        self.state_[key] = self.marshal(value)
 
-    def get_state(self):
-        # type: () -> Any
-        return self.state_
+    def get(self, key):
+        # type: () -> Text
+        return self.demarshal(self.state_[key])
 
-    @contextmanager
-    def state(self, default):
-        # type: (Any) -> Any
-        new_state = self.get_state() or default
-        yield new_state
-        self.set_state(new_state)
+    def contains(self, key):
+        # type: (Text) -> bool
+        return key in self.state_
 
 class ExternalBotHandler(object):
     def __init__(self, client, root_dir):

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -79,7 +79,7 @@ class ExternalBotHandler(object):
         self._rate_limit = RateLimit(20, 5)
         self._client = client
         self._root_dir = root_dir
-        self.state_handler = StateHandler()
+        self.storage = StateHandler()
         try:
             self.user_id = user_profile['user_id']
             self.full_name = user_profile['full_name']

--- a/zulip_bots/zulip_bots/test_lib.py
+++ b/zulip_bots/zulip_bots/test_lib.py
@@ -104,7 +104,9 @@ class BotTestCase(TestCase):
         if state_handler is None:
             state_handler = StateHandler()
         # Send message to the concerned bot
-        self.message_handler.handle_message(message, self.MockClass(None, None), state_handler)
+        mock_bot_handler = self.MockClass(None, None)
+        mock_bot_handler.state_handler = state_handler
+        self.message_handler.handle_message(message, mock_bot_handler)
 
         # Check if the bot is sending a message via `send_message` function.
         # Where response is a dictionary here.

--- a/zulip_bots/zulip_bots/test_lib.py
+++ b/zulip_bots/zulip_bots/test_lib.py
@@ -61,11 +61,6 @@ class BotTestCase(TestCase):
         # type: (Union[Sequence[Tuple[str, Any]], Dict[str, Any]], str, str, str, str, int, str, str) -> None
         # To test send_message, Any would be a Dict type,
         # to test send_reply, Any would be a str type.
-        if isinstance(expectations, dict):
-            expected = [(k, v) for k, v in expectations.items()]
-        else:
-            expected = expectations
-
         if type not in ["private", "stream", "all"]:
             logging.exception("check_expected_response expects type to be 'private', 'stream' or 'all'")
 

--- a/zulip_bots/zulip_bots/test_lib.py
+++ b/zulip_bots/zulip_bots/test_lib.py
@@ -41,7 +41,7 @@ class BotTestCase(TestCase):
     def setUp(self):
         # type: () -> None
         # Mocking ExternalBotHandler
-        self.patcher = patch('zulip_bots.lib.ExternalBotHandler')
+        self.patcher = patch('zulip_bots.lib.ExternalBotHandler', autospec=True)
         self.MockClass = self.patcher.start()
         self.message_handler = self.get_bot_message_handler()
 
@@ -51,7 +51,7 @@ class BotTestCase(TestCase):
 
     def initialize_bot(self):
         # type: () -> None
-        self.message_handler.initialize(self.MockClass())
+        self.message_handler.initialize(self.MockClass(None, None))
 
     def check_expected_responses(self, expectations, expected_method='send_reply',
                                  email="foo_sender@zulip.com", recipient="foo", subject="foo",
@@ -104,7 +104,7 @@ class BotTestCase(TestCase):
         if state_handler is None:
             state_handler = StateHandler()
         # Send message to the concerned bot
-        self.message_handler.handle_message(message, self.MockClass(), state_handler)
+        self.message_handler.handle_message(message, self.MockClass(None, None), state_handler)
 
         # Check if the bot is sending a message via `send_message` function.
         # Where response is a dictionary here.


### PR DESCRIPTION
This enables `virtual_fs` to store the state in the bot state model when run as an embedded bot.

I use `pickle` to serialize each `fs` object, to store it as a string in the model. I'm aware of the potential security hazards coming with pickle, but I assume its usage here to be fine, since pickle does only deserialize what it once has serialized itself. Every object pickle serializes is a dictionary at its most outer level, so no code injection should be possible.

This will be required for https://github.com/zulip/zulip/pull/6927, where `virtual_fs` is added as an embedded bot.