### PR TITLE
 zulip_bots: Enforce default config file schema.

### DIFF
--- a/zulip_bots/zulip_bots/bots/github_detail/github_detail.conf
+++ b/zulip_bots/zulip_bots/bots/github_detail/github_detail.conf
@@ -1,0 +1,3 @@
+[github_detail]
+owner = <repository owner>
+repo = <repository name>

--- a/zulip_bots/zulip_bots/bots/weather/weather.conf
+++ b/zulip_bots/zulip_bots/bots/weather/weather.conf
@@ -1,2 +1,2 @@
-[weather-config]
+[weather]
 key=XXXXXXXX

--- a/zulip_bots/zulip_bots/bots/weather/weather.py
+++ b/zulip_bots/zulip_bots/bots/weather/weather.py
@@ -5,7 +5,7 @@ import json
 
 class WeatherHandler(object):
     def initialize(self, bot_handler):
-        self.api_key = bot_handler.get_config_info('weather', 'weather-config')['key']
+        self.api_key = bot_handler.get_config_info('weather')['key']
         self.response_pattern = 'Weather in {}, {}:\n{:.2f} F / {:.2f} C\n{}'
 
     def usage(self):

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -119,10 +119,9 @@ class ExternalBotHandler(object):
         else:
             self._rate_limit.show_error_and_exit()
 
-    def get_config_info(self, bot_name, section=None, optional=False):
-        # type: (str, Optional[str], Optional[bool]) -> Dict[str, Any]
+    def get_config_info(self, bot_name, optional=False):
+        # type: (str, Optional[bool]) -> Dict[str, Any]
         conf_file_path = os.path.realpath(os.path.join(self._root_dir, bot_name + '.conf'))
-        section = section or bot_name
         config = configparser.ConfigParser()
         try:
             with open(conf_file_path) as conf:
@@ -131,7 +130,7 @@ class ExternalBotHandler(object):
             if optional:
                 return dict()
             raise
-        return dict(config.items(section))
+        return dict(config.items(bot_name))
 
     def open(self, filepath):
         # type: (str) -> IO[str]


### PR DESCRIPTION
In the end, I decided against removing the section name. While it is redundant, ConfigParser works only with sections and makes config parsing very convenient. This makes the change for the external bots to comply with embedded bots really straightforward.