### PR TITLE
zulip_bots: Add common tests to bot testing framework.

### DIFF
--- a/tools/test-bots
+++ b/tools/test-bots
@@ -8,6 +8,7 @@ import sys
 import argparse
 import glob
 import unittest
+from unittest import TestCase, TestSuite
 
 def load_tests_from_modules(names, template):
     loader = unittest.defaultTestLoader
@@ -90,6 +91,19 @@ def main():
             template='zulip_bots.bots.{name}.test_{name}')
     else:
         test_suites = load_all_tests()
+
+    def filter_tests(tests):
+        # type: (Union[TestSuite, TestCase]) -> TestSuite
+        filtered_tests = TestSuite()
+        for test in tests:
+            if isinstance(test, TestCase):
+                # Exclude test base class from being tested.
+                if 'BotTestCase' not in test.__class__.__name__:
+                    filtered_tests.addTest(test)
+            else:
+                filtered_tests.addTest(filter_tests(test))
+        return filtered_tests
+    test_suites = filter_tests(test_suites)
 
     suite = unittest.TestSuite(test_suites)
     runner = unittest.TextTestRunner(verbosity=2)

--- a/zulip_bots/zulip_bots/bots/encrypt/encrypt.py
+++ b/zulip_bots/zulip_bots/bots/encrypt/encrypt.py
@@ -39,7 +39,3 @@ class EncryptHandler(object):
         return send_content
 
 handler_class = EncryptHandler
-
-if __name__ == '__main__':
-    assert encrypt('ABCDabcd1234') == 'NOPQnopq1234'
-    assert encrypt('NOPQnopq1234') == 'ABCDabcd1234'

--- a/zulip_bots/zulip_bots/bots/github_detail/test_github_detail.py
+++ b/zulip_bots/zulip_bots/bots/github_detail/test_github_detail.py
@@ -5,10 +5,18 @@ from __future__ import print_function
 
 import json
 
-from zulip_bots.test_lib import BotTestCase
+from zulip_bots.test_lib import BotTestCaseBase
 
-class TestGithubDetailBot(BotTestCase):
+class TestGithubDetailBot(BotTestCaseBase):
     bot_name = "github_detail"
+    mock_config = {'owner': 'zulip', 'repo': 'zulip'}
+
+    # Overrides default test_bot_usage().
+    def test_bot_usage(self):
+        # type: () -> None
+        with self.mock_config_info(self.mock_config):
+            self.initialize_bot()
+            self.assertNotEqual(self.message_handler.usage(), '')
 
     def test_issue(self):
         bot_response = '**[zulip/zulip#5365](https://github.com/zulip/zulip/issues/5365)'\
@@ -75,8 +83,7 @@ class TestGithubDetailBot(BotTestCase):
                        'the default repo is zulip.'
         # This message calls the `send_reply` function of BotHandlerApi
 
-        mock_config = {'owner': 'zulip', 'repo': 'zulip'}
-        with self.mock_config_info(mock_config):
+        with self.mock_config_info(self.mock_config):
             self.initialize_bot()
             self.assert_bot_response(
                 message = {'content': 'help'},

--- a/zulip_bots/zulip_bots/test_lib.py
+++ b/zulip_bots/zulip_bots/test_lib.py
@@ -26,7 +26,7 @@ from types import ModuleType
 
 from copy import deepcopy
 
-class BotTestCase(TestCase):
+class BotTestCaseBase(TestCase):
     bot_name = ''  # type: str
 
     def get_bot_message_handler(self):
@@ -153,3 +153,8 @@ class BotTestCase(TestCase):
         # Strictly speaking, this function is not needed anymore,
         # kept for now for legacy reasons.
         self.call_request(message, expected_method, response)
+
+class BotTestCase(BotTestCaseBase):
+    def test_bot_usage(self):
+        # type: () -> None
+        self.assertNotEqual(self.message_handler.usage(), '')


### PR DESCRIPTION
This took some experimenting, since unittest doesn't cover this sort of thing. A nice effect is that we have a cheap jump for several bots to 100% coverage.

Because `test_lib.py` gets completely rewritten in the diff, I split out the first commit, which does not alter BotTestCase(TestCase) in any way. This should make it easier to review.

This addresses #122 and moves encrypt, followup, helloworld, help, incrementor, and weather to 100% coverage.