### PR TITLE
Ignore prior coverage data in tools/test-main.

### DIFF
--- a/tools/test-main
+++ b/tools/test-main
@@ -2,6 +2,6 @@
 
 set -ev
 
-tools/test-bots --coverage combine
+tools/test-bots --coverage
 tools/test-botserver --coverage combine
 tools/test-zulip --coverage combine


### PR DESCRIPTION
Before this patch, we were reading in old coverage data every
time we ran test-main and had a .coverage file lying around.
This would cause inaccurate data when you changed code, and it
would cause crashes if you moved your working directory on the
file system.