### PR TITLE
Report client.get_profile() errors nicely (e.g. API key).

### DIFF
--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -106,6 +106,13 @@ class ExternalBotHandler(object):
                 '''.format(e))
             sys.exit(1)
 
+        if user_profile.get('result') == 'error':
+            msg = user_profile.get('msg', 'unknown')
+            print('''
+                ERROR: {}
+                '''.format(msg))
+            sys.exit(1)
+
         self._rate_limit = RateLimit(20, 5)
         self._client = client
         self._root_dir = root_dir


### PR DESCRIPTION
This patch is particularly useful in the scenario that your
API key is wrong or out of date, but it's targeted more
generally at any error that `client.get_profile()` reports.