### PR TITLE
bots: Clean up terminal.py for running bots directly.

### DIFF
--- a/zulip_bots/zulip_bots/simple_lib.py
+++ b/zulip_bots/zulip_bots/simple_lib.py
@@ -1,4 +1,5 @@
 import configparser
+import sys
 
 class SimpleStorage:
     def __init__(self):
@@ -49,10 +50,7 @@ class TerminalBotHandler:
         return self.message_server.send(message)
 
     def send_reply(self, message, response):
-        print('''
-            reply:
-            {}
-            '''.format(response))
+        print("\nReply from the bot is printed between the dotted lines:\n-------\n{}\n-------".format(response))
         response_message = dict(
             content=response
         )

--- a/zulip_bots/zulip_bots/terminal.py
+++ b/zulip_bots/zulip_bots/terminal.py
@@ -56,18 +56,23 @@ def main():
 
     sender_email = 'foo_sender@zulip.com'
 
-    while True:
-        content = input('Enter your message: ')
+    try:
+        while True:
+            content = input('Enter your message: ')
 
-        message = dict(
-            content=content,
-            sender_email=sender_email,
-            display_recipient=sender_email,
-        )
-        message_handler.handle_message(
-            message=message,
-            bot_handler=bot_handler,
-        )
+            message = dict(
+                content=content,
+                sender_email=sender_email,
+                display_recipient=sender_email,
+            )
+            message_handler.handle_message(
+                message=message,
+                bot_handler=bot_handler,
+            )
+    except KeyboardException:
+        print("\n\nOk, if you're happy with your terminal-based testing, try it out with a Zulip server.",
+              "\nYou can refer to https://zulipchat.com/api/running-bots#running-a-bot.")
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Make terminal.py exit gracefully with a message.
Modify output bot reply for better understanding for multi-line bot output. For example:
```
>python3 terminal.py --bot-config-file bots/weather/weather.conf weather 
Enter your message: New York

            reply:
            Weather in New York, US:
51.53 F / 10.85 C
Scattered Clouds
```

On providing no config file flag in simple_lib.py for a bot that uses conf, throws the following error:
`NameError: name 'sys' is not defined`
Corrected this.