### PR TITLE
docs: Mention Python 3 in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This repository contains the source code for Zulip's PyPI packages:
 * `zulip_botserver`: [PyPI package](https://pypi.python.org/pypi/zulip-botserver)
   for Zulip's Flask bot server.
 
+The source code is written in *Python 3*.
+
 ## Development
 
 1. Fork and clone the Git repo:


### PR DESCRIPTION
As mentioned in [this Zulip conversation](https://chat.zulip.org/#narrow/stream/GCI.20tasks/subject/Python.202.20or.203.20in.20python-zulip-api/near/347329), the docs don't mention whether or not to use Python 2 or 3, so I made a commit to make it more clear.