### PR TITLE
zulip_bots: Test POST requests in `mock_http_conversation`.

### DIFF
--- a/zulip_bots/zulip_bots/test_lib.py
+++ b/zulip_bots/zulip_bots/test_lib.py
@@ -159,13 +159,6 @@ def read_bot_fixture_data(bot_name, test_name):
     http_data = json.loads(content)
     return http_data
 
-def get_response(http_response, http_headers):
-    # type: (Dict[str, Any], Dict[str, Any]) -> Any
-    mock_result = requests.Response()
-    mock_result._content = json.dumps(http_response).encode()  # type: ignore # This modifies a "hidden" attribute.
-    mock_result.status_code = http_headers.get('status', 200)
-    return mock_result
-
 @contextmanager
 def mock_http_conversation(http_data):
     # type: (Dict[str, Any]) -> Any
@@ -178,6 +171,31 @@ def mock_http_conversation(http_data):
     http_data should be fixtures data formatted like the data
     in zulip_bots/zulip_bots/bots/giphy/fixtures/test_normal.json
     """
+    def get_response(http_response, http_headers):
+        # type: (Dict[str, Any], Dict[str, Any]) -> Any
+        """Creates a fake `requests` Response with a desired HTTP response and
+        response headers.
+        """
+        mock_result = requests.Response()
+        mock_result._content = json.dumps(http_response).encode()  # type: ignore # This modifies a "hidden" attribute.
+        mock_result.status_code = http_headers.get('status', 200)
+        return mock_result
+
+    def assert_called_with_fields(mock_result, http_request, fields):
+        # type: (Any, Dict[str, Any], List[str]) -> None
+        """Calls `assert_called_with` on a mock object using an HTTP request.
+        Uses `fields` to determine which keys to look for in HTTP request and
+        to test; if a key is in `fields`, e.g., 'headers', it will be used in
+        the assertion.
+        """
+        args = {}
+
+        for field in fields:
+            if field in http_request:
+                args[field] = http_request[field]
+
+        mock_result.assert_called_with(http_request['api_url'], **args)
+
     http_request = http_data.get('request')
     http_response = http_data.get('response')
     http_headers = http_data.get('response-headers')
@@ -187,30 +205,20 @@ def mock_http_conversation(http_data):
         with patch('requests.get') as mock_get:
             mock_get.return_value = get_response(http_response, http_headers)
             yield
-            if 'params' in http_request:
-                params = http_request.get('params', None)
-                mock_get.assert_called_with(http_request['api_url'], params=params)
-            elif 'headers' in http_request:
-                headers = http_request.get('headers', None)
-                mock_get.assert_called_with(http_request['api_url'], headers=headers)
-            else:
-                mock_get.assert_called_with(http_request['api_url'])
+            assert_called_with_fields(
+                mock_get,
+                http_request,
+                ['params', 'headers']
+            )
     else:
         with patch('requests.post') as mock_post:
             mock_post.return_value = get_response(http_response, http_headers)
             yield
-            if 'json' in http_request:
-                json = http_request.get('json', None)
-                if 'params' in http_request:
-                    params = http_request.get('params', None)
-                    mock_post.assert_called_with(http_request['api_url'], json=json, params=params)
-                else:
-                    mock_post.assert_called_with(http_request['api_url'], json=json)
-            elif 'params' in http_request:
-                params = http_request.get('params', None)
-                mock_post.assert_called_with(http_request['api_url'], params=params)
-            else:
-                mock_post.assert_called_with(http_request['api_url'])
+            assert_called_with_fields(
+                mock_post,
+                http_request,
+                ['params', 'headers', 'json']
+            )
 
 class BotTestCase(StubBotTestCase):
     """Test class for common Bot test helper methods"""


### PR DESCRIPTION
As of now, only GET requests are supported by `mock_http_conversation`. However, this creates problems as some APIs utilize POST requests instead of GET ones. Therefore, create a system for using POST requests. (See https://goo.gl/p77qab for a discussion of this on the Zulip #integrations stream.)

To use a POST request with `mock_http_conversation`, specify
`"method": "POST"` in the `"request"` options of a fixture. For example,

    "request": {
      "api_url": "https://example.com/api",
      "method": "POST",
      "params": {
        "foo": "bar",
        "baz": "qwerty"
      },
      "json": {
        "baz": "qwerty"
      }
    },