### PR TITLE
zulip_bots: Make typing import work in Python 3.5.

### DIFF
--- a/zulip_bots/zulip_bots/run.py
+++ b/zulip_bots/zulip_bots/run.py
@@ -9,7 +9,9 @@ import os
 from types import ModuleType
 from importlib import import_module
 from os.path import basename, splitext
-from typing import Any, Optional, Text
+
+if False:
+    from typing import Any, Optional, Text
 
 from zulip_bots.lib import (
     run_message_handler_for_bot,


### PR DESCRIPTION
See https://github.com/python/mypy/issues/1838.