### PR TITLE
Add automatic testing of responses to empty messages

### DIFF
--- a/zulip_bots/zulip_bots/bots/giphy/test_giphy.py
+++ b/zulip_bots/zulip_bots/bots/giphy/test_giphy.py
@@ -9,6 +9,11 @@ from zulip_bots.test_lib import StubBotHandler, StubBotTestCase, get_bot_message
 class TestGiphyBot(StubBotTestCase):
     bot_name = "giphy"
 
+    # Override default function in StubBotTestCase
+    def test_bot_responds_to_empty_message(self) -> None:
+        # FIXME?: Giphy does not respond to empty messages
+        pass
+
     def test_normal(self) -> None:
         bot_response = '[Click to enlarge]' \
                        '(https://media4.giphy.com/media/3o6ZtpxSZbQRRnwCKQ/giphy.gif)' \

--- a/zulip_bots/zulip_bots/bots/github_detail/test_github_detail.py
+++ b/zulip_bots/zulip_bots/bots/github_detail/test_github_detail.py
@@ -22,6 +22,11 @@ class TestGithubDetailBot(StubBotTestCase):
 
         self.assertIn('displays details on github issues', bot.usage())
 
+    # Override default function in StubBotTestCase
+    def test_bot_responds_to_empty_message(self) -> None:
+        with self.mock_config_info(self.mock_config):
+            self.verify_reply('', 'Failed to find any issue or PR.')
+
     def test_issue(self) -> None:
         request = 'zulip/zulip#5365'
         bot_response = '**[zulip/zulip#5365](https://github.com/zulip/zulip/issues/5365)'\

--- a/zulip_bots/zulip_bots/bots/googletranslate/test_googletranslate.py
+++ b/zulip_bots/zulip_bots/bots/googletranslate/test_googletranslate.py
@@ -63,7 +63,8 @@ class TestGoogleTranslateBot(BotTestCase):
                         expected_method = 'send_reply'
                     )
 
-    def test_help_empty(self):
+    # Override default function in StubBotTestCase
+    def test_bot_responds_to_empty_message(self):
         with self.mock_config_info({'key': 'abcdefg'}), \
                 self.mock_http_conversation('test_languages'):
             self.initialize_bot()

--- a/zulip_bots/zulip_bots/bots/weather/test_weather.py
+++ b/zulip_bots/zulip_bots/bots/weather/test_weather.py
@@ -10,6 +10,25 @@ from typing import Any
 class TestWeatherBot(BotTestCase):
     bot_name = "weather"
 
+    help_content = '''
+            This bot returns weather info for specified city.
+            You specify city in the following format:
+            city, state/country
+            state and country parameter is optional(useful when there are many cities with the same name)
+            For example:
+            @**Weather Bot** Portland
+            @**Weather Bot** Portland, Me
+            '''.strip()
+
+    # Override default function in StubBotTestCase
+    def test_bot_responds_to_empty_message(self) -> None:
+        bot_response = self.help_content
+        self.assert_bot_response(
+            message = {'content': ''},
+            response = {'content': bot_response},
+            expected_method='send_reply'
+        )
+
     def test_bot(self) -> None:
 
         # City query
@@ -55,28 +74,11 @@ class TestWeatherBot(BotTestCase):
                 response = {'content': bot_response},
                 expected_method='send_reply'
             )
-        help_content = '''
-            This bot returns weather info for specified city.
-            You specify city in the following format:
-            city, state/country
-            state and country parameter is optional(useful when there are many cities with the same name)
-            For example:
-            @**Weather Bot** Portland
-            @**Weather Bot** Portland, Me
-            '''.strip()
 
         # help message
-        bot_response = help_content
+        bot_response = self.help_content
         self.assert_bot_response(
             message = {'content': 'help'},
-            response = {'content': bot_response},
-            expected_method='send_reply'
-        )
-
-        # empty message
-        bot_response = help_content
-        self.assert_bot_response(
-            message = {'content': ''},
             response = {'content': bot_response},
             expected_method='send_reply'
         )

--- a/zulip_bots/zulip_bots/bots/yoda/test_yoda.py
+++ b/zulip_bots/zulip_bots/bots/yoda/test_yoda.py
@@ -10,6 +10,27 @@ from zulip_bots.test_lib import BotTestCase
 class TestYodaBot(BotTestCase):
     bot_name = "yoda"
 
+    # Override default function in StubBotTestCase
+    def test_bot_responds_to_empty_message(self):
+        bot_response = '''
+            This bot allows users to translate a sentence into
+            'Yoda speak'.
+            Users should preface messages with '@mention-bot'.
+
+            Before running this, make sure to get a Mashape Api token.
+            Instructions are in the 'readme.md' file.
+            Store it in the 'yoda.conf' file.
+            The 'yoda.conf' file should be located in this bot's (zulip_bots/bots/yoda/yoda)
+            directory.
+            Example input:
+            @mention-bot You will learn how to speak like me someday.
+            '''
+        self.assert_bot_response(
+            message = {'content': ''},
+            response = {'content': bot_response},
+            expected_method='send_reply'
+        )
+
     def test_bot(self):
 
         # Test normal sentence (1).
@@ -64,26 +85,6 @@ class TestYodaBot(BotTestCase):
             '''
         self.assert_bot_response(
             message = {'content': 'help'},
-            response = {'content': bot_response},
-            expected_method='send_reply'
-        )
-
-        # Test empty message.
-        bot_response = '''
-            This bot allows users to translate a sentence into
-            'Yoda speak'.
-            Users should preface messages with '@mention-bot'.
-
-            Before running this, make sure to get a Mashape Api token.
-            Instructions are in the 'readme.md' file.
-            Store it in the 'yoda.conf' file.
-            The 'yoda.conf' file should be located in this bot's (zulip_bots/bots/yoda/yoda)
-            directory.
-            Example input:
-            @mention-bot You will learn how to speak like me someday.
-            '''
-        self.assert_bot_response(
-            message = {'content': ''},
             response = {'content': bot_response},
             expected_method='send_reply'
         )

--- a/zulip_bots/zulip_bots/bots/youtube/test_youtube.py
+++ b/zulip_bots/zulip_bots/bots/youtube/test_youtube.py
@@ -13,6 +13,21 @@ class TestYoutubeBot(StubBotTestCase):
                       'number_of_results': '5',
                       'video_region': 'US'}  # type: Dict[str,str]
 
+    help_content = "*Help for YouTube bot* :robot_face: : \n\n" \
+                   "The bot responds to messages starting with @mention-bot.\n\n" \
+                   "`@mention-bot <search terms>` will return top Youtube video for the given `<search term>`.\n" \
+                   "`@mention-bot top <search terms>` also returns the top Youtube result.\n" \
+                   "`@mention-bot list <search terms>` will return a list Youtube videos for the given <search term>.\n \n" \
+                   "Example:\n" \
+                   " * @mention-bot funny cats\n" \
+                   " * @mention-bot list funny dogs"
+
+    # Override default function in StubBotTestCase
+    def test_bot_responds_to_empty_message(self) -> None:
+        with self.mock_config_info(self.normal_config), \
+                self.mock_http_conversation('test_keyok'):
+                    self.verify_reply('', self.help_content)
+
     def test_single(self) -> None:
         bot_response = 'Here is what I found for `funny cats` : \n'\
                        'Cats are so funny you will die laughing - ' \
@@ -55,22 +70,13 @@ class TestYoutubeBot(StubBotTestCase):
             self.verify_reply('somethingrandomwithnoresult', bot_response,)
 
     def test_help(self) -> None:
-        help_content = "*Help for YouTube bot* :robot_face: : \n\n" \
-                       "The bot responds to messages starting with @mention-bot.\n\n" \
-                       "`@mention-bot <search terms>` will return top Youtube video for the given `<search term>`.\n" \
-                       "`@mention-bot top <search terms>` also returns the top Youtube result.\n" \
-                       "`@mention-bot list <search terms>` will return a list Youtube videos for the given <search term>.\n \n" \
-                       "Example:\n" \
-                       " * @mention-bot funny cats\n" \
-                       " * @mention-bot list funny dogs"
-
+        help_content = self.help_content
         with self.mock_config_info(self.normal_config), \
                 self.mock_http_conversation('test_keyok'):
                     self.verify_reply('help', help_content)
                     self.verify_reply('list', help_content)
                     self.verify_reply('help list', help_content)
                     self.verify_reply('top', help_content)
-                    self.verify_reply('', help_content)
 
     def test_connection_error(self) -> None:
         with self.mock_config_info(self.normal_config), \

--- a/zulip_bots/zulip_bots/test_lib.py
+++ b/zulip_bots/zulip_bots/test_lib.py
@@ -142,6 +142,24 @@ class StubBotTestCase(TestCase):
         bot = get_bot_message_handler(self.bot_name)
         self.assertNotEqual(bot.usage(), '')
 
+    def test_bot_responds_to_empty_message(self) -> None:
+        # TODO get_response should be usable here once it's merged?
+        bot = get_bot_message_handler(self.bot_name)
+        bot_handler = StubBotHandler()
+
+        if hasattr(bot, 'initialize'):
+            bot.initialize(bot_handler)
+
+        message = dict(
+            sender_email='foo@example.com',
+            display_recipient='foo',
+            content='',
+        )
+        bot_handler.reset_transcript()
+        bot.handle_message(message, bot_handler)
+        empty_response = bot_handler.unique_response()
+        self.assertIsNotNone(empty_response)
+
     def mock_http_conversation(self, test_name):
         # type: (str) -> Any
         assert test_name is not None


### PR DESCRIPTION
This is an alternative testing-based (rather than default-behavior-based) approach to #58, which also could fix #55 - though again, via tests (test_lib.py), rather than lib.py.

This follows the idea I saw introduced with `test_bot_usage`. I ended up overriding the function in a few bots, though I had originally planned to keep it as local to test_lib.py as possible.

@showell You seem to be taking a lead on tests atm, so tagging you for review/comments.