### PR TITLE
mypy: Add annotations for bots.

### DIFF
--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -60,6 +60,8 @@ force_include = [
     "zulip_bots/zulip_bots/bots/encrypt/test_encrypt.py",
     "zulip_bots/zulip_bots/bots/chess/chess.py",
     "zulip_bots/zulip_bots/bots/chess/test_chess.py",
+    "zulip_bots/zulip_bots/bots/xkcd/xkcd.py",
+    "zulip_bots/zulip_bots/bots/xkcd/test_xkcd.py",
 ]
 
 parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -64,6 +64,8 @@ force_include = [
     "zulip_bots/zulip_bots/bots/xkcd/test_xkcd.py",
     "zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py",
     "zulip_bots/zulip_bots/bots/wikipedia/test_wikipedia.py",
+    "zulip_bots/zulip_bots/bots/yoda/yoda.py",
+    "zulip_bots/zulip_bots/bots/yoda/test_yoda.py",
 ]
 
 parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -62,6 +62,8 @@ force_include = [
     "zulip_bots/zulip_bots/bots/chess/test_chess.py",
     "zulip_bots/zulip_bots/bots/xkcd/xkcd.py",
     "zulip_bots/zulip_bots/bots/xkcd/test_xkcd.py",
+    "zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py",
+    "zulip_bots/zulip_bots/bots/wikipedia/test_wikipedia.py",
 ]
 
 parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")

--- a/zulip_bots/zulip_bots/bots/wikipedia/test_wikipedia.py
+++ b/zulip_bots/zulip_bots/bots/wikipedia/test_wikipedia.py
@@ -5,7 +5,7 @@ from zulip_bots.test_lib import StubBotTestCase
 class TestWikipediaBot(StubBotTestCase):
     bot_name = "wikipedia"
 
-    def test_bot(self):
+    def test_bot(self) -> None:
 
         # Single-word query
         bot_request = 'happy'

--- a/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
+++ b/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
@@ -4,6 +4,8 @@ import requests
 import logging
 import re
 from six.moves import urllib
+from zulip_bots.lib import ExternalBotHandler
+from typing import Optional
 
 # See readme.md for instructions on running this code.
 
@@ -24,7 +26,7 @@ class WikipediaHandler(object):
         'description': 'Searches Wikipedia for a term and returns the top 3 articles.',
     }
 
-    def usage(self):
+    def usage(self) -> str:
         return '''
             This plugin will allow users to directly search
             Wikipedia for a specific key term and get the top 3
@@ -32,11 +34,11 @@ class WikipediaHandler(object):
             should preface searches with "@mention-bot".
             @mention-bot <name of article>'''
 
-    def handle_message(self, message, bot_handler):
+    def handle_message(self, message: dict, bot_handler: ExternalBotHandler) -> None:
         bot_response = self.get_bot_wiki_response(message, bot_handler)
         bot_handler.send_reply(message, bot_response)
 
-    def get_bot_wiki_response(self, message, bot_handler):
+    def get_bot_wiki_response(self, message: dict, bot_handler: ExternalBotHandler) -> Optional[str]:
         '''This function returns the URLs of the requested topic.'''
 
         help_text = 'Please enter your search term after @mention-bot'
@@ -54,12 +56,12 @@ class WikipediaHandler(object):
 
         except requests.exceptions.RequestException:
             logging.error('broken link')
-            return
+            return None
 
         # Checking if the bot accessed the link.
         if data.status_code != 200:
             logging.error('Page not found.')
-            return
+            return None
         new_content = 'For search term:' + query + '\n'
 
         # Checking if there is content for the searched term

--- a/zulip_bots/zulip_bots/bots/xkcd/test_xkcd.py
+++ b/zulip_bots/zulip_bots/bots/xkcd/test_xkcd.py
@@ -7,7 +7,7 @@ from zulip_bots.test_lib import StubBotTestCase
 class TestXkcdBot(StubBotTestCase):
     bot_name = "xkcd"
 
-    def test_latest_command(self):
+    def test_latest_command(self) -> None:
         bot_response = ("#1866: **Russell's Teapot**\n"
                         "[Unfortunately, NASA regulations state that Bertrand Russell-related "
                         "payloads can only be launched within launch vehicles which do not launch "
@@ -15,7 +15,7 @@ class TestXkcdBot(StubBotTestCase):
         with self.mock_http_conversation('test_latest'):
             self.verify_reply('latest', bot_response)
 
-    def test_random_command(self):
+    def test_random_command(self) -> None:
         bot_response = ("#1800: **Chess Notation**\n"
                         "[I've decided to score all my conversations using chess win-loss "
                         "notation. (??)](https://imgs.xkcd.com/comics/chess_notation.png)")
@@ -27,14 +27,14 @@ class TestXkcdBot(StubBotTestCase):
                 randint.return_value = mock_rand_value.return_value
                 self.verify_reply('random', bot_response)
 
-    def test_numeric_comic_id_command_1(self):
+    def test_numeric_comic_id_command_1(self) -> None:
         bot_response = ("#1: **Barrel - Part 1**\n[Don't we all.]"
                         "(https://imgs.xkcd.com/comics/barrel_cropped_(1).jpg)")
         with self.mock_http_conversation('test_specific_id'):
             self.verify_reply('1', bot_response)
 
     @mock.patch('logging.exception')
-    def test_invalid_comic_ids(self, mock_logging_exception):
+    def test_invalid_comic_ids(self, mock_logging_exception: mock.Mock) -> None:
         invalid_id_txt = "Sorry, there is likely no xkcd comic strip with id: #"
 
         for comic_id, fixture in (('0', 'test_not_existing_id_2'),
@@ -42,7 +42,7 @@ class TestXkcdBot(StubBotTestCase):
             with self.mock_http_conversation(fixture):
                 self.verify_reply(comic_id, invalid_id_txt + comic_id)
 
-    def test_help_responses(self):
+    def test_help_responses(self) -> None:
         help_txt = "xkcd bot supports these commands:"
         err_txt  = "xkcd bot only supports these commands, not `{}`:"
         commands = '''

--- a/zulip_bots/zulip_bots/bots/xkcd/xkcd.py
+++ b/zulip_bots/zulip_bots/bots/xkcd/xkcd.py
@@ -2,6 +2,7 @@ import random
 
 import logging
 import requests
+from zulip_bots.lib import ExternalBotHandler
 
 XKCD_TEMPLATE_URL = 'https://xkcd.com/%s/info.0.json'
 LATEST_XKCD_URL = 'https://xkcd.com/info.0.json'
@@ -19,7 +20,7 @@ class XkcdHandler(object):
         'description': 'Fetches comic strips from https://xkcd.com.',
     }
 
-    def usage(self):
+    def usage(self) -> str:
         return '''
             This plugin allows users to fetch a comic strip provided by
             https://xkcd.com. Users should preface the command with "@mention-bot".
@@ -32,7 +33,7 @@ class XkcdHandler(object):
             `<comic_id>`, e.g `@mention-bot 1234`.
             '''
 
-    def handle_message(self, message, bot_handler):
+    def handle_message(self, message: dict, bot_handler: ExternalBotHandler) -> None:
         xkcd_bot_response = get_xkcd_bot_response(message)
         bot_handler.send_reply(message, xkcd_bot_response)
 
@@ -47,7 +48,7 @@ class XkcdNotFoundError(Exception):
 class XkcdServerError(Exception):
     pass
 
-def get_xkcd_bot_response(message):
+def get_xkcd_bot_response(message: dict) -> str:
     original_content = message['content'].strip()
     command = original_content.strip()
 
@@ -82,7 +83,7 @@ def get_xkcd_bot_response(message):
                                            fetched['alt'],
                                            fetched['img']))
 
-def fetch_xkcd_query(mode, comic_id=None):
+def fetch_xkcd_query(mode: int, comic_id: str = None) -> dict:
     try:
         if mode == XkcdBotCommand.LATEST:  # Fetch the latest comic strip.
             url = LATEST_XKCD_URL
@@ -111,7 +112,7 @@ def fetch_xkcd_query(mode, comic_id=None):
 
         xkcd_json = fetched.json()
     except requests.exceptions.ConnectionError as e:
-        logging.warning(e)
+        logging.exception("Connection Error")
         raise
 
     return xkcd_json

--- a/zulip_bots/zulip_bots/bots/yoda/test_yoda.py
+++ b/zulip_bots/zulip_bots/bots/yoda/test_yoda.py
@@ -11,7 +11,7 @@ class TestYodaBot(BotTestCase):
     bot_name = "yoda"
 
     # Override default function in StubBotTestCase
-    def test_bot_responds_to_empty_message(self):
+    def test_bot_responds_to_empty_message(self) -> None:
         bot_response = '''
             This bot allows users to translate a sentence into
             'Yoda speak'.
@@ -31,8 +31,7 @@ class TestYodaBot(BotTestCase):
             expected_method='send_reply'
         )
 
-    def test_bot(self):
-
+    def test_bot(self) -> None:
         # Test normal sentence (1).
         bot_response = "Learn how to speak like me someday, you will. Yes, hmmm."
 


### PR DESCRIPTION
Add annotations for xkcd, Wikipedia, and Yoda Bot.

Also, make a few minor changes inside of some functions to accommodate for the new typing:
 1. Use `return None` instead of just `return` in [`get_bot_wiki_response` for Wikipedia Bot](https://github.com/zulip/python-zulip-api/compare/master...skunkmb:add-bots-mypy-6?expand=1#diff-f466b0b628423593f706fa17fa3e1601R67).
 2. Use `logging.warning(str(e))` instead of `logging.warning(e)` in [`fetch_xkcd_query` for xkcd Bot](https://github.com/zulip/python-zulip-api/compare/master...skunkmb:add-bots-mypy-6?expand=1#diff-2414b1dc9f66a1edc5cc2950c177e52fR119).
 3. Use `response.json()` instead of `response.text` in [`send_to_yoda_api` for Yoda Bot.](https://github.com/zulip/python-zulip-api/compare/master...skunkmb:add-bots-mypy-6?expand=1#diff-d20394f5dc43134ad0ac41457d27cb23R81)