### PR TITLE
Improvements to wikpedia bot and tests for define bot

### DIFF
--- a/zulip_bots/zulip_bots/bots/define/test_define.py
+++ b/zulip_bots/zulip_bots/bots/define/test_define.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from zulip_bots.test_lib import StubBotTestCase
+from unittest.mock import patch
 
 class TestDefineBot(StubBotTestCase):
     bot_name = "define"
@@ -46,3 +47,10 @@ class TestDefineBot(StubBotTestCase):
         # Empty messages are returned with a prompt to reply. No request is sent to the Internet.
         bot_response = "Please enter a word to define."
         self.verify_reply('', bot_response)
+
+    def test_connection_error(self) -> None:
+        with patch('requests.get', side_effect=Exception), \
+                patch('logging.exception'):
+            self.verify_reply(
+                'aeroplane',
+                '**aeroplane**:\nCould not load definition.')

--- a/zulip_bots/zulip_bots/bots/wikipedia/test_wikipedia.py
+++ b/zulip_bots/zulip_bots/bots/wikipedia/test_wikipedia.py
@@ -59,12 +59,13 @@ class TestWikipediaBot(StubBotTestCase):
 
         # Incorrect status code
         bot_request = 'Zulip'
-        bot_response = None
+        bot_response = 'Uh-Oh ! Sorry ,couldn\'t process the request right now.:slightly_frowning_face:\n' \
+                       'Please try again later.'
+
         with self.mock_http_conversation('test_status_code'):
             self.verify_reply(bot_request, bot_response)
 
         # Request Exception
         bot_request = 'Z'
-        bot_response = None
         with mock_request_exception():
             self.verify_reply(bot_request, bot_response)

--- a/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
+++ b/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
@@ -56,12 +56,15 @@ class WikipediaHandler(object):
 
         except requests.exceptions.RequestException:
             logging.error('broken link')
-            return None
+            return 'Uh-Oh ! Sorry ,couldn\'t process the request right now.:slightly_frowning_face:\n' \
+                   'Please try again later.'
 
         # Checking if the bot accessed the link.
         if data.status_code != 200:
             logging.error('Page not found.')
-            return None
+            return 'Uh-Oh ! Sorry ,couldn\'t process the request right now.:slightly_frowning_face:\n' \
+                   'Please try again later.'
+
         new_content = 'For search term:' + query + '\n'
 
         # Checking if there is content for the searched term


### PR DESCRIPTION
This PR brings 100%  test coverage define bot.
Also when exploring the  wikipedia bot , I found that the bot replied with `null` in case of an error which is not  the very best response for the a normal user. So I made a change to return an error message incase of an error.