### PR TITLE
Remove markdown includes {!running-bot.md!} from bot docs.

### DIFF
--- a/zulip_bots/zulip_bots/bots/giphy/doc.md
+++ b/zulip_bots/zulip_bots/bots/giphy/doc.md
@@ -25,7 +25,7 @@ GIPHY API key.
    and change the value of the `key` attribute to the API key
    you generated above.
 
-{!running-a-bot.md!}
+Run this bot as described in [here](https://zulipchat.com/api/running-bots#running-a-bot).
 
 ## Usage
 

--- a/zulip_bots/zulip_bots/bots/xkcd/doc.md
+++ b/zulip_bots/zulip_bots/bots/xkcd/doc.md
@@ -8,7 +8,7 @@ like so:
 @xkcd <command>
 ```
 
-{!running-a-bot.md!}
+Run this bot as described in [here](https://zulipchat.com/api/running-bots#running-a-bot).
 
 ## Usage
 

--- a/zulip_bots/zulip_bots/bots/youtube/doc.md
+++ b/zulip_bots/zulip_bots/bots/youtube/doc.md
@@ -29,7 +29,6 @@ To obtain a API key, follow the following steps :
     you generated above.
 
  6. And that's it ! See Configuration section on configuring the bot.
-{!running-a-bot.md!}
 
 ## Configuration
 
@@ -41,6 +40,8 @@ This section explains the usage of options `youtube.conf` file in configuring th
 
  - `video_region` - The location to be used for searching.
    The bot shows only the videos that are available in the given `<video_region>`
+
+Run this bot as described in [here](https://zulipchat.com/api/running-bots#running-a-bot).
 
 ## Usage
 


### PR DESCRIPTION
Remove markdown includes from bot docs and inserted a link instead, cause markdown includes doesn't seem work(as shown in image).

![runningbot](https://user-images.githubusercontent.com/25907420/34051845-085ef628-e1e6-11e7-9edf-610aa1bb1e7a.png)

