### PR TITLE
Update dialogflow bot to show user friendly messages

### DIFF
--- a/zulip_bots/zulip_bots/bots/dialogflow/dialogflow.py
+++ b/zulip_bots/zulip_bots/bots/dialogflow/dialogflow.py
@@ -23,12 +23,13 @@ def get_bot_result(message_content: str, config: Dict[str, str], sender_id: str)
         response = request.getresponse()
         res_str = response.read().decode('utf8', 'ignore')
         res_json = json.loads(res_str)
-        if res_json['status']['errorType'] != 'success':
+        if res_json['status']['errorType'] != 'success' and 'result' not in res_json.keys():
             return 'Error {}: {}.'.format(res_json['status']['code'], res_json['status']['errorDetails'])
         if res_json['result']['fulfillment']['speech'] == '':
-            if res_json['alternateResult']['fulfillment']['speech'] == '':
-                return 'Error. No result.'
-            return res_json['alternateResult']['fulfillment']['speech']
+            if 'alternateResult' in res_json.keys():
+                if res_json['alternateResult']['fulfillment']['speech'] != '':
+                    return res_json['alternateResult']['fulfillment']['speech']
+            return 'Error. No result.'
         return res_json['result']['fulfillment']['speech']
     except Exception as e:
         logging.exception(str(e))


### PR DESCRIPTION
These changes improve the dialogflow bot by:

 - Instead of sending the actual error e.g. `error 204: error 500 internal server error.`, the bot will now send the message sent, if available, e.g. `could not get the weather.`
 - Fixed mistake where if the dialogflow sent an empty message with no alternate response, it would raise a KeyError.