### PR TITLE
mypy: Include strict-optional by default when running tools/run-mypy

### DIFF
--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -97,8 +97,8 @@ parser.add_argument('--no-disallow-untyped-defs', dest='disallow_untyped_defs', 
                     help="""Don't throw errors when functions are not annotated""")
 parser.add_argument('--scripts-only', dest='scripts_only', action='store_true', default=False,
                     help="""Only type check extensionless python scripts""")
-parser.add_argument('--strict-optional', dest='strict_optional', action='store_true', default=False,
-                    help="""Use the --strict-optional flag with mypy""")
+parser.add_argument('--no-strict-optional', dest='strict_optional', action='store_false', default=True,
+                    help="""Don't use the --strict-optional flag with mypy""")
 parser.add_argument('--warn-unused-ignores', dest='warn_unused_ignores', action='store_true', default=False,
                     help="""Use the --warn-unused-ignores flag with mypy""")
 parser.add_argument('--no-ignore-missing-imports', dest='ignore_missing_imports', action='store_false', default=True,

--- a/zulip/integrations/hg/zulip-changegroup.py
+++ b/zulip/integrations/hg/zulip-changegroup.py
@@ -106,12 +106,13 @@ def send_zulip(email, api_key, site, stream, subject, content):
     client.send_message(message_data)
 
 def get_config(ui, item):
-    # type: (ui, str) -> Optional[str]
+    # type: (ui, str) -> str
     try:
         # configlist returns everything in lists.
         return ui.configlist('zulip', item)[0]
     except IndexError:
-        return None
+        ui.warn("Zulip: Could not find required item {} in hg config.".format(item))
+        exit(1)
 
 def hook(ui, repo, **kwargs):
     # type: (ui, repo, **Text) -> None

--- a/zulip/integrations/hg/zulip-changegroup.py
+++ b/zulip/integrations/hg/zulip-changegroup.py
@@ -28,6 +28,7 @@
 from __future__ import absolute_import
 
 import zulip
+import sys
 from six.moves import range
 from typing import Any, Optional, Text
 from mercurial import ui, repo
@@ -112,7 +113,7 @@ def get_config(ui, item):
         return ui.configlist('zulip', item)[0]
     except IndexError:
         ui.warn("Zulip: Could not find required item {} in hg config.".format(item))
-        exit(1)
+        sys.exit(1)
 
 def hook(ui, repo, **kwargs):
     # type: (ui, repo, **Text) -> None
@@ -126,7 +127,7 @@ def hook(ui, repo, **kwargs):
 
     if hooktype != "changegroup":
         ui.warn("Zulip: {hooktype} not supported\n".format(hooktype=hooktype))
-        exit(1)
+        sys.exit(1)
 
     ctx = repo.changectx(node)
     branch = ctx.branch()
@@ -140,14 +141,14 @@ def hook(ui, repo, **kwargs):
         watched_branches = [b.lower().strip() for b in branch_whitelist.split(",")]
         if branch.lower() not in watched_branches:
             ui.debug("Zulip: ignoring event for {branch}\n".format(branch=branch))
-            exit(0)
+            sys.exit(0)
 
     if branch_blacklist:
         # Don't send notifications for branches we've ignored.
         ignored_branches = [b.lower().strip() for b in branch_blacklist.split(",")]
         if branch.lower() in ignored_branches:
             ui.debug("Zulip: ignoring event for {branch}\n".format(branch=branch))
-            exit(0)
+            sys.exit(0)
 
     # The first and final commits in the changeset.
     base = repo[node].rev()
@@ -160,7 +161,7 @@ def hook(ui, repo, **kwargs):
     if not (email and api_key):
         ui.warn("Zulip: missing email or api_key configurations\n")
         ui.warn("in the [zulip] section of your .hg/hgrc.\n")
-        exit(1)
+        sys.exit(1)
 
     stream = get_config(ui, "stream")
     # Give a default stream if one isn't provided.

--- a/zulip/integrations/jabber/jabber_mirror_backend.py
+++ b/zulip/integrations/jabber/jabber_mirror_backend.py
@@ -405,7 +405,11 @@ option does not affect login credentials.'''.replace("\n", " "))
                         format='%(levelname)-8s %(message)s')
 
     if options.zulip_config_file is None:
-        config_file = zulip.get_default_config_filename()
+        default_config_file = zulip.get_default_config_filename()
+        if default_config_file is not None:
+            config_file = default_config_file
+        else:
+            config_error("Config file not found via --zulip-config_file or environment variable.")
     else:
         config_file = options.zulip_config_file
 

--- a/zulip/integrations/jabber/jabber_mirror_backend.py
+++ b/zulip/integrations/jabber/jabber_mirror_backend.py
@@ -94,7 +94,7 @@ class JabberToZulipBot(ClientXMPP):
         self.rooms_to_join = rooms
         self.add_event_handler("session_start", self.session_start)
         self.add_event_handler("message", self.message)
-        self.zulip = None  # type: Client
+        self.zulip = None
         self.use_ipv6 = False
 
         self.register_plugin('xep_0045')  # Jabber chatrooms
@@ -216,7 +216,7 @@ class ZulipToJabberBot(object):
     def __init__(self, zulip_client):
         # type: (Client) -> None
         self.client = zulip_client
-        self.jabber = None  # type: JabberToZulipBot
+        self.jabber = None
 
     def set_jabber_client(self, client):
         # type: (JabberToZulipBot) -> None
@@ -243,6 +243,7 @@ class ZulipToJabberBot(object):
 
     def stream_message(self, msg):
         # type: (Dict[str, str]) -> None
+        assert(self.jabber is not None)
         stream = msg['display_recipient']
         if not stream.endswith("/xmpp"):
             return
@@ -258,6 +259,7 @@ class ZulipToJabberBot(object):
 
     def private_message(self, msg):
         # type: (Dict[str, Any]) -> None
+        assert(self.jabber is not None)
         for recipient in msg['display_recipient']:
             if recipient["email"] == self.client.email:
                 continue
@@ -274,6 +276,7 @@ class ZulipToJabberBot(object):
 
     def process_subscription(self, event):
         # type: (Dict[str, Any]) -> None
+        assert(self.jabber is not None)
         if event['op'] == 'add':
             streams = [s['name'].lower() for s in event['subscriptions']]
             streams = [s for s in streams if s.endswith("/xmpp")]
@@ -287,6 +290,7 @@ class ZulipToJabberBot(object):
 
     def process_stream(self, event):
         # type: (Dict[str, Any]) -> None
+        assert(self.jabber is not None)
         if event['op'] == 'occupy':
             streams = [s['name'].lower() for s in event['streams']]
             streams = [s for s in streams if s.endswith("/xmpp")]

--- a/zulip/integrations/svn/post-commit
+++ b/zulip/integrations/svn/post-commit
@@ -66,10 +66,11 @@ message = "**{0}** committed revision r{1} to `{2}`.\n\n> {3}".format(
 
 destination = config.commit_notice_destination(path, rev)  # type: Optional[Dict[Text, Text]]
 
-message_data = {
-    "type": "stream",
-    "to": destination["stream"],
-    "subject": destination["subject"],
-    "content": message,
-}  # type: Dict[str, Any]
-client.send_message(message_data)
+if destination is not None:
+    message_data = {
+        "type": "stream",
+        "to": destination["stream"],
+        "subject": destination["subject"],
+        "content": message,
+    }  # type: Dict[str, Any]
+    client.send_message(message_data)

--- a/zulip/integrations/zephyr/check-mirroring
+++ b/zulip/integrations/zephyr/check-mirroring
@@ -125,7 +125,7 @@ def send_zephyr(zwrite_args, content):
 # Subscribe to Zulip
 try:
     res = zulip_client.register(event_types=["message"])
-    if 'error' in res.get('result'):
+    if 'error' in res['result']:
         logging.error("Error subscribing to Zulips!")
         logging.error(res['msg'])
         print_status_and_exit(1)
@@ -263,8 +263,8 @@ logger.info("Starting receiving messages!")
 
 # receive zulips
 res = zulip_client.get_events(queue_id=queue_id, last_event_id=last_event_id)
-if 'error' in res.get('result'):
-    logging.error("Error subscribing to Zulips!")
+if 'error' in res['result']:
+    logging.error("Error receiving Zulips!")
     logging.error(res['msg'])
     print_status_and_exit(1)
 messages = [event['message'] for event in res['events']]

--- a/zulip/integrations/zephyr/zephyr_mirror_backend.py
+++ b/zulip/integrations/zephyr/zephyr_mirror_backend.py
@@ -252,7 +252,7 @@ def maybe_restart_mirroring_script():
                 time.sleep(1)
 
 def process_loop(log):
-    # type: (IO[Any]) -> None
+    # type: (Optional[IO[Any]]) -> None
     restart_check_count = 0
     last_check_time = time.time()
     while True:
@@ -362,7 +362,7 @@ def decrypt_zephyr(zephyr_class, instance, body):
     return decrypted
 
 def process_notice(notice, log):
-    # type: (zulip, IO[Any]) -> None
+    # type: (zulip, Optional[IO[Any]]) -> None
     (zsig, body) = parse_zephyr_body(notice.message, notice.format)
     is_personal = False
     is_huddle = False
@@ -954,7 +954,7 @@ def open_logger():
     return logger
 
 def configure_logger(logger, direction_name):
-    # type: (logging.Logger, str) -> None
+    # type: (logging.Logger, Optional[str]) -> None
     if direction_name is None:
         log_format = "%(message)s"
     else:
@@ -1162,7 +1162,7 @@ or specify the --api-key-file option.""" % (options.api_key_file,))))
         options.session_path = "/var/tmp/%s" % (options.user,)
 
     if options.forward_from_zulip:
-        child_pid = os.fork()  # type: int
+        child_pid = os.fork()  # type: Optional[int]
         if child_pid == 0:
             CURRENT_STATE = States.ZulipToZephyr
             # Run the zulip => zephyr mirror in the child

--- a/zulip/integrations/zephyr/zephyr_mirror_backend.py
+++ b/zulip/integrations/zephyr/zephyr_mirror_backend.py
@@ -21,7 +21,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from __future__ import absolute_import
-from typing import IO, Any, Dict, List, Text, Union, Set, Tuple, Optional
+from typing import IO, Any, Dict, List, Text, Union, Set, Tuple, Optional, cast
 from types import FrameType
 
 import sys
@@ -48,7 +48,7 @@ class States(object):
     Startup, ZulipToZephyr, ZephyrToZulip, ChildSending = list(range(4))
 CURRENT_STATE = States.Startup
 
-logger = None  # type: logging.Logger
+logger = cast(logging.Logger, None)  # type: logging.Logger  # FIXME cast should not be needed?
 
 def to_zulip_username(zephyr_username):
     # type: (str) -> str

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -337,6 +337,7 @@ class Client(object):
             raise RuntimeError("api_key or email not specified and file %s does not exist"
                                % (config_file,))
 
+        assert(api_key is not None and email is not None)
         self.api_key = api_key
         self.email = email
         self.verbose = verbose

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -588,7 +588,7 @@ class Client(object):
                 else:
                     res = self.register(event_types=event_types, narrow=narrow)
 
-                if 'error' in res.get('result'):
+                if 'error' in res['result']:
                     if self.verbose:
                         print("Server returned error:\n%s" % res['msg'])
                     time.sleep(1)
@@ -604,7 +604,7 @@ class Client(object):
                 (queue_id, last_event_id) = do_register()
 
             res = self.get_events(queue_id=queue_id, last_event_id=last_event_id)
-            if 'error' in res.get('result'):
+            if 'error' in res['result']:
                 if res["result"] == "http-error":
                     if self.verbose:
                         print("HTTP error fetching events -- probably a server restart")

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -397,7 +397,8 @@ class Client(object):
 
         # Build a client cert object for requests
         if self.client_cert_key is not None:
-            client_cert = (self.client_cert, self.client_cert_key)  # type: Union[str, Tuple[str, str]]
+            assert(self.client_cert is not None)  # Otherwise RuntimeError near end of __init__
+            client_cert = (self.client_cert, self.client_cert_key)  # type: Union[None, str, Tuple[str, str]]
         else:
             client_cert = self.client_cert
 

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -461,6 +461,7 @@ class Client(object):
             req_files.append((f.name, f))
 
         self.ensure_session()
+        assert(self.session is not None)
 
         query_state = {
             'had_error_retry': False,


### PR DESCRIPTION
Outstanding issues are within the api (zulip/zulip/__init__.py) and various integrations, totalling 21 errors locally. Pending review, all but the tools/run-mypy change should be mergeable now.

**Jan 8th 2018** Initial patches were merged in #251, so I rebased here and added commits which should resolve all outstanding mypy+strict-optional issues. The tools commit is now the last commit, but github does not show the correct order.