### PR TITLE
Test run_message_handler_for_bot() and add a 'full_message' field for bots.

### DIFF
--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -280,12 +280,13 @@ def run_message_handler_for_bot(lib_module, quiet, config_file, bot_config_file,
     def handle_message(message, flags):
         # type: (Dict[str, Any], List[str]) -> None
         logging.info('waiting for next message')
-
         # `mentioned` will be in `flags` if the bot is mentioned at ANY position
         # (not necessarily the first @mention in the message).
         is_mentioned = 'mentioned' in flags
         is_private_message = is_private_message_from_another_user(message, restricted_client.user_id)
 
+        # Provide bots with a way to access the full, unstripped message
+        message['full_content'] = message['content']
         # Strip at-mention botname from the message
         if is_mentioned:
             # message['content'] will be None when the bot's @-mention is not at the beginning.

--- a/zulip_bots/zulip_bots/lib_tests.py
+++ b/zulip_bots/zulip_bots/lib_tests.py
@@ -6,7 +6,7 @@ from zulip_bots.lib import (
 )
 
 class FakeClient:
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         self.storage = dict()
 
     def get_profile(self):

--- a/zulip_bots/zulip_bots/lib_tests.py
+++ b/zulip_bots/zulip_bots/lib_tests.py
@@ -114,7 +114,8 @@ class LibTest(TestCase):
                 original_message = {'content': '@**Alice** bar',
                                     'type': 'stream'}
                 expected_message = {'type': 'stream',
-                                    'content': 'bar'}
+                                    'content': 'bar',
+                                    'full_content': '@**Alice** bar'}
                 test_message(original_message, {'mentioned'})
                 mock_bot_handler.handle_message.assert_called_with(
                     message=expected_message,


### PR DESCRIPTION
Note that currently, the test for `run_message_handler_for_bot()` validates only one message. The framework is built though, and adding new test messages is straightforward.