### PR TITLE
presence: Make a request to `mark_bot_listening` when a bot starts.

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -673,6 +673,17 @@ class Client(object):
             request=message_data,
         )
 
+    def mark_bot_listening(self, bot_name, is_listening):
+        # type: (str, bool) -> Dict[str, Any]
+        return self.call_endpoint(
+            url='realm/mark_bot_listening',
+            method='POST',
+            request={
+                'bot_name': bot_name,
+                'is_listening': is_listening
+            }
+        )
+
     def get_events(self, **request):
         # type: (**Any) -> Dict[str, Any]
         '''

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -7,6 +7,7 @@ import signal
 import sys
 import time
 import re
+import atexit
 
 from six.moves import configparser
 
@@ -304,6 +305,14 @@ def run_message_handler_for_bot(lib_module, quiet, config_file, bot_config_file,
     signal.signal(signal.SIGINT, exit_gracefully)
 
     logging.info('starting message handling...')
+
+    client.mark_bot_listening(bot_name, True)
+
+    def mark_bot_is_not_listening():
+        # type: () -> None
+        client.mark_bot_listening(bot_name, False)
+
+    atexit.register(mark_bot_is_not_listening)
 
     def event_callback(event):
         # type: (Dict[str, Any]) -> None

--- a/zulip_bots/zulip_bots/lib_tests.py
+++ b/zulip_bots/zulip_bots/lib_tests.py
@@ -34,6 +34,9 @@ class FakeClient:
     def send_message(self, message):
         pass
 
+    def mark_bot_listening(realm, bot_name, is_listening):
+        pass
+
 class LibTest(TestCase):
     def test_basics(self):
         client = FakeClient()


### PR DESCRIPTION
(This pull request should only be merged after/if zulip/zulip#7938 is merged.)

zulip/zulip#7938 creates a mechanism for marking a bot as `listening` and displaying it in the presence sidebar if it is. This PR calls that endpoint whenever a bot is started/stopped so that it displayed.