### PR TITLE
Add ExternalBotHandler.quit()

### DIFF
--- a/zulip_bots/zulip_bots/bots/youtube/test_youtube.py
+++ b/zulip_bots/zulip_bots/bots/youtube/test_youtube.py
@@ -39,7 +39,7 @@ class TestYoutubeBot(BotTestCase):
 
         with self.mock_config_info({'key': 'somethinginvalid', 'number_of_results': '5', 'video_region': 'US'}), \
                 self.mock_http_conversation('test_invalid_key'), \
-                self.assertRaises(SystemExit) as se:  # type: ignore
+                self.assertRaises(bot_handler.BotQuitException):
                     bot.initialize(bot_handler)
 
     def test_multiple(self) -> None:

--- a/zulip_bots/zulip_bots/bots/youtube/youtube.py
+++ b/zulip_bots/zulip_bots/bots/youtube/youtube.py
@@ -31,9 +31,8 @@ class YoutubeHandler(object):
             search_youtube('test', self.config_info['key'], self.config_info['video_region'])
         except HTTPError as e:
             if (e.response.json()['error']['errors'][0]['reason'] == 'keyInvalid'):
-                logging.error('Invalid key.'
-                              'Follow the instructions in doc.md for setting API key.')
-                sys.exit(1)
+                bot_handler.quit('Invalid key.'
+                                 'Follow the instructions in doc.md for setting API key.')
             else:
                 raise
         except ConnectionError:

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -210,6 +210,10 @@ class ExternalBotHandler(object):
             raise PermissionError("Cannot open file \"{}\". Bots may only access "
                                   "files in their local directory.".format(abs_filepath))
 
+    def quit(self, message = ""):
+        # type: (str) -> None
+        sys.exit(message)
+
 def extract_query_without_mention(message, client):
     # type: (Dict[str, Any], ExternalBotHandler) -> str
     """

--- a/zulip_bots/zulip_bots/test_lib.py
+++ b/zulip_bots/zulip_bots/test_lib.py
@@ -45,6 +45,13 @@ class StubBotHandler:
         # type: (Dict[str, Any]) -> None
         self.message_server.update(message)
 
+    class BotQuitException(Exception):
+        pass
+
+    def quit(self, message = ""):
+        # type: (str) -> None
+        raise self.BotQuitException()
+
     def get_config_info(self, bot_name, optional=False):
         # type: (str, bool) -> Dict[str, Any]
         return None


### PR DESCRIPTION
@showell can you review the approach I took here?

If you agree, I'll update the other bots currently using sys.exit(), and the ones using logging.error() where quit() should be used.