### PR TITLE
requirements: Remove runtime dependency on mock.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ crayons
 twine
 coverage>=4.4.1
 pycodestyle==2.3.1
+mock
 -e ./zulip
 -e ./zulip_bots
 -e ./zulip_botserver

--- a/zulip/setup.py
+++ b/zulip/setup.py
@@ -55,7 +55,6 @@ setuptools_info = dict(
     install_requires=['requests>=0.12.1',
                       'six',
                       'typing>=3.5.2.2',
-                      'mock',
                       ],
 )
 

--- a/zulip_botserver/setup.py
+++ b/zulip_botserver/setup.py
@@ -38,7 +38,6 @@ setuptools_info = dict(
         'zulip',
         'zulip_bots',
         'flask>=0.12.2',
-        'mock',
     ],
 )
 


### PR DESCRIPTION
The zulip and zulip_botserver packages specify mock as a runtime
dependency, which is only needed for testing during development.
So, it made more sense to move it to requirements.txt so that
it can be installed by ./tools/provision during development.

Fixes #293.

@roberthoenig FYI :)