### PR TITLE
zulip: Change remove_subscriptions to update_subscriptions.

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -810,12 +810,15 @@ class Client(object):
             request=request,
         )
 
-    def remove_subscriptions(self, streams):
-        # type: (Iterable[str]) -> Dict[str, Any]
+    def update_subscriptions(self, add=[], delete=[]):
+        # type: (Optional[Iterable[Dict[str, Any]]], Optional[Iterable[str]]) -> Dict[str, Any]
         '''
             See examples/unsubscribe for example usage.
         '''
-        request = dict(delete=streams)
+        request = dict(
+            delete=delete,
+            add=add,
+        )
         return self.call_endpoint(
             url='users/me/subscriptions',
             method='PATCH',

--- a/zulip/zulip/examples/unsubscribe
+++ b/zulip/zulip/examples/unsubscribe
@@ -43,4 +43,4 @@ options = parser.parse_args()
 
 client = zulip.init_from_options(options)
 
-print(client.remove_subscriptions(options.streams.split()))
+print(client.update_subscriptions(delete=options.streams.split()))


### PR DESCRIPTION
The underlying endpoint that remove_subscriptions called was
zerver.streams.view.update_subscriptions_backend, which is more
for bulk removing *and* adding subscriptions. Also there is a
separate endpoint for removing subscriptions that gives more
control than this one. So this method should be more aptly
called update_subscriptions and should allow one to add
subscriptions as well.

Note that once we make the next PyPI release and update the main
repo to use it, ./zulip/tools/test-api should fail, and would
need to be updated in the PR that updates the main repo to use
the latest release of the packages.

@roberthoenig, @showell: Could I please get a quick review? Thanks! :)