### PR TITLE
zulip: Make a DELETE request in remove_subscriptions.

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -810,15 +810,18 @@ class Client(object):
             request=request,
         )
 
-    def remove_subscriptions(self, streams):
-        # type: (Iterable[str]) -> Dict[str, Any]
+    def remove_subscriptions(self, streams, principals=[]):
+        # type: (Iterable[str], Optional[Iterable[str]]) -> Dict[str, Any]
         '''
             See examples/unsubscribe for example usage.
         '''
-        request = dict(delete=streams)
+        request = dict(
+            subscriptions=streams,
+            principals=principals
+        )
         return self.call_endpoint(
             url='users/me/subscriptions',
-            method='PATCH',
+            method='DELETE',
             request=request,
         )
 


### PR DESCRIPTION
Previously, remove_subscriptions called the
PATCH /api/v1/users/me/subscriptions endpoint, which is more like
an ad-hoc endpoint for bulk adding/removing subscriptions for the
user that makes the request. However, making a DELETE request
allows an admin to pass in the `principals` argument to unsubscribe
other users from streams as well, which is more consistent with how
add_subscriptions works.

@showell: FYI :)