### PR TITLE
zephyr_mirror_backend.py: Remove duplicate import.

### DIFF
--- a/zulip/integrations/zephyr/zephyr_mirror_backend.py
+++ b/zulip/integrations/zephyr/zephyr_mirror_backend.py
@@ -35,7 +35,6 @@ import optparse
 import os
 import datetime
 import textwrap
-import time
 import signal
 import logging
 import hashlib


### PR DESCRIPTION
I wrote a script to find duplicate imports, and this was the only one it could find.