### PR TITLE
bots: Add magic method validate_config().

### DIFF
--- a/zulip_bots/zulip_bots/bots/giphy/test_giphy.py
+++ b/zulip_bots/zulip_bots/bots/giphy/test_giphy.py
@@ -29,18 +29,22 @@ class TestGiphyBot(BotTestCase):
                 'Sorry, I don\'t have a GIF for "world without zulip"! :astonished:',
             )
 
-    def test_403(self) -> None:
+    def test_invalid_config(self) -> None:
         bot = get_bot_message_handler(self.bot_name)
         bot_handler = StubBotHandler()
+        with self.mock_http_conversation('test_403'):
+            self.validate_invalid_config({'key': '12345678'},
+                                         "This is likely due to an invalid key.\n")
 
-        with self.mock_config_info({'key': '12345678'}), \
-                self.mock_http_conversation('test_403'),  \
-                self.assertRaises(bot_handler.BotQuitException):
-            bot.initialize(bot_handler)
+    def test_valid_config(self) -> None:
+        bot = get_bot_message_handler(self.bot_name)
+        bot_handler = StubBotHandler()
+        with self.mock_http_conversation('test_normal'):
+            self.validate_valid_config({'key': '12345678'})
 
     def test_connection_error_while_running(self) -> None:
         with self.mock_config_info({'key': '12345678'}), \
-                patch('requests.get', side_effect=[MagicMock(), ConnectionError()]), \
+                patch('requests.get', side_effect=[ConnectionError()]), \
                 patch('logging.exception'):
             self.verify_reply(
                 'world without chocolate',

--- a/zulip_bots/zulip_bots/custom_exceptions.py
+++ b/zulip_bots/zulip_bots/custom_exceptions.py
@@ -1,0 +1,11 @@
+# This file implements some custom exceptions that can
+# be used by all bots.
+# We avoid adding these exceptions to lib.py, because the
+# current architecture works by lib.py importing bots, not
+# the other way around.
+
+class ConfigValidationError(Exception):
+    '''
+    Raise if the config data passed to a bot's validate_config()
+    is invalid (e.g. wrong API key, invalid email, etc.).
+    '''

--- a/zulip_bots/zulip_bots/lib_tests.py
+++ b/zulip_bots/zulip_bots/lib_tests.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, patch, ANY
+from unittest.mock import MagicMock, patch, ANY, create_autospec
 from zulip_bots.lib import (
     ExternalBotHandler,
     StateHandler,
@@ -32,6 +32,16 @@ class FakeClient:
         )
 
     def send_message(self, message):
+        pass
+
+class FakeBotHandler:
+    def usage(self):
+        return '''
+            This is a fake bot handler that is used
+            to spec BotHandler mocks.
+            '''
+
+    def handle_message(self, message, bot_handler):
         pass
 
 class LibTest(TestCase):
@@ -99,7 +109,7 @@ class LibTest(TestCase):
             mock_lib_module = MagicMock()
             # __file__ is not mocked by MagicMock(), so we assign a mock value manually.
             mock_lib_module.__file__ = "foo"
-            mock_bot_handler = MagicMock()
+            mock_bot_handler = create_autospec(FakeBotHandler)
             mock_lib_module.handler_class.return_value = mock_bot_handler
 
             def call_on_each_event_mock(self, callback, event_types=None, narrow=None):

--- a/zulip_bots/zulip_bots/test_lib.py
+++ b/zulip_bots/zulip_bots/test_lib.py
@@ -3,6 +3,10 @@ from unittest import TestCase
 
 from typing import List, Dict, Any, Tuple
 
+from zulip_bots.custom_exceptions import (
+    ConfigValidationError,
+)
+
 from zulip_bots.request_test_lib import (
     mock_http_conversation,
 )
@@ -148,6 +152,15 @@ class BotTestCase(TestCase):
             bot.handle_message(message, bot_handler)
             response = bot_handler.unique_response()
             self.assertEqual(expected_response, response['content'])
+
+    def validate_invalid_config(self, config_data: Dict[str, str], error_regexp: str) -> None:
+        bot_class = type(get_bot_message_handler(self.bot_name))
+        with self.assertRaisesRegexp(ConfigValidationError, error_regexp):
+            bot_class.validate_config(config_data)
+
+    def validate_valid_config(self, config_data: Dict[str, str]) -> None:
+        bot_class = type(get_bot_message_handler(self.bot_name))
+        bot_class.validate_config(config_data)
 
     def test_bot_usage(self):
         # type: () -> None


### PR DESCRIPTION
This method allows bots to validate their config info
in a standardized way. Adding the method to a bot is
optional, but recommended for bots with config options
that can be invalid, like api keys. The giphy bot serves
as an example.
The primary reason behind this is to allow the zulip
backend to validate config data for embedded bots. The
backend does not have a permanent bot class instance, so
validate_config() must be a static method.