### PR TITLE
game_handler: Use avatars instead of emails in game handler messages.

### DIFF
--- a/zulip_bots/zulip_bots/bots/game_handler_bot/test_game_handler_bot.py
+++ b/zulip_bots/zulip_bots/bots/game_handler_bot/test_game_handler_bot.py
@@ -228,7 +228,7 @@ class TestGameHandlerBot(BotTestCase):
             }
         }
         self.verify_response(
-            'quit', 'Game cancelled.\nfoo@example.com quit.', 0, bot, 'foo')
+            'quit', 'Game cancelled.\n!avatar(foo@example.com) **foo** quit.', 0, bot, 'foo')
 
     def test_user_already_in_game_errors(self) -> None:
         bot = self.setup_game()
@@ -312,14 +312,14 @@ class TestGameHandlerBot(BotTestCase):
 
     def test_normal_turns(self) -> None:
         bot = self.setup_game()
-        self.verify_response('move 3', '**foo** moved in column 3\n\nfoo\n\nIt\'s @**baz**\'s (:red_circle:) turn.',
+        self.verify_response('move 3', '**foo** moved in column 3\n\nfoo\n\n!avatar(baz@example.com) It\'s **baz**\'s (:red_circle:) turn.',
                              0, bot=bot, stream='test', subject='test game')
-        self.verify_response('move 3', '**baz** moved in column 3\n\nfoo\n\nIt\'s @**foo**\'s (:blue_circle:) turn.',
+        self.verify_response('move 3', '**baz** moved in column 3\n\nfoo\n\n!avatar(foo@example.com) It\'s **foo**\'s (:blue_circle:) turn.',
                              0, bot=bot, stream='test', subject='test game', user_name='baz')
 
     def test_wrong_turn(self) -> None:
         bot = self.setup_game()
-        self.verify_response('move 5', 'It\'s @**foo**\'s (:blue_circle:) turn.', 0,
+        self.verify_response('move 5', '!avatar(foo@example.com) It\'s **foo**\'s (:blue_circle:) turn.', 0,
                              bot=bot, stream='test', subject='test game', user_name='baz')
 
     def test_private_message_error(self) -> None:
@@ -389,7 +389,7 @@ class TestGameHandlerBot(BotTestCase):
         bot = self.setup_game()
         bot.put_user_cache()
         with patch('zulip_bots.bots.game_handler_bot.game_handler_bot.MockModel.determine_game_over', return_value='foo@example.com'):
-            self.verify_response('move 3', 'foo@example.com won! :tada:',
+            self.verify_response('move 3', '!avatar(foo@example.com) **foo** won! :tada:',
                                  1, bot=bot, stream='test', subject='test game')
         leaderboard = '**Most wins**\n\n\
 Player | Games Won | Games Drawn | Games Lost | Total Games\n\
@@ -402,12 +402,12 @@ Player | Games Won | Games Drawn | Games Lost | Total Games\n\
     def test_current_turn_winner(self) -> None:
         bot = self.setup_game()
         with patch('zulip_bots.bots.game_handler_bot.game_handler_bot.MockModel.determine_game_over', return_value='current turn'):
-            self.verify_response('move 3', 'foo@example.com won! :tada:',
+            self.verify_response('move 3', '!avatar(foo@example.com) **foo** won! :tada:',
                                  1, bot=bot, stream='test', subject='test game')
 
     def test_computer_turn(self) -> None:
         bot = self.setup_computer_game()
-        self.verify_response('move 3', '**foo** moved in column 3\n\nfoo\n\nIt\'s @**test-bot**\'s (:red_circle:) turn.',
+        self.verify_response('move 3', '**foo** moved in column 3\n\nfoo\n\n!avatar(test-bot@example.com) It\'s **test-bot**\'s (:red_circle:) turn.',
                              0, bot=bot, stream='test', subject='test game')
         with patch('zulip_bots.bots.game_handler_bot.game_handler_bot.MockModel.determine_game_over', return_value='test-bot@example.com'):
             self.verify_response('move 5', 'I won! Well Played!',
@@ -461,7 +461,7 @@ Player | Games Won | Games Drawn | Games Lost | Total Games\n\
     def test_parse_message(self) -> None:
         bot = self.setup_game()
         self.verify_response('move 3', 'Join your game using the link below!\n\n> **Game `abc123`**\n\
-> foo@example.com\n\
+> !avatar(foo@example.com)\n\
 > foo test game\n\
 > 2/2 players\n\
 > **[Join Game](/#narrow/stream/test/topic/test game)**', 0, bot=bot)
@@ -470,7 +470,7 @@ Player | Games Won | Games Drawn | Games Lost | Total Games\n\
 To move subjects, send your message again, otherwise join the game using the link below.
 
 > **Game `abc123`**
-> foo@example.com
+> !avatar(foo@example.com)
 > foo test game
 > 2/2 players
 > **[Join Game](/#narrow/stream/test/topic/test game)**''', 0, bot=bot, stream='test 2', subject='game 2')
@@ -484,7 +484,7 @@ To move subjects, send your message again, otherwise join the game using the lin
 To move subjects, send your message again, otherwise join the game using the link below.
 
 > **Game `abcdefg`**
-> bar@example.com
+> !avatar(bar@example.com)
 > foo test game
 > 2/2 players
 > **[Join Game](/#narrow/stream/test2/topic/test game 2)**''', 0, bot=bot, user_name='bar', stream='test game', subject='test2')

--- a/zulip_bots/zulip_bots/game_handler.py
+++ b/zulip_bots/zulip_bots/game_handler.py
@@ -315,7 +315,9 @@ class GameAdapter(object):
         if game_id is '':
             self.send_reply(
                 message, 'You are not in a game. Type `help` for all commands.')
-        self.cancel_game(game_id, reason='{} quit.'.format(sender))
+        sender_avatar = "!avatar({})".format(sender)
+        sender_name = self.get_username_by_email(sender)
+        self.cancel_game(game_id, reason='{} **{}** quit.'.format(sender_avatar, sender_name))
 
     def command_join(self, message: Dict[str, Any], sender: str, content: str) -> None:
         if not self.is_user_not_player(sender, message):
@@ -486,7 +488,9 @@ class GameAdapter(object):
         return num
 
     def get_host(self, game_id: str) -> str:
-        return self.get_players(game_id)[0]
+        player_email = self.get_players(game_id)[0]
+        player_avatar = "!avatar({})".format(player_email)
+        return player_avatar
 
     def parse_message(self, message: Dict[str, Any]) -> None:
         game_id = self.is_user_in_game(message['sender_email'])
@@ -715,7 +719,7 @@ class GameInstance(object):
         player_text = ''
         for player in self.players:
             player_text += ' @**{}**'.format(
-                self.gameAdapter.get_user_by_email(player)['full_name'])
+                self.gameAdapter.get_username_by_email(player))
         return player_text
 
     def get_start_message(self) -> str:
@@ -748,7 +752,9 @@ class GameInstance(object):
         if self.is_turn_of(player_email):
             self.handle_current_player_command(content)
         else:
-            self.broadcast('It\'s @**{}**\'s ({}) turn.'.format(
+            user_turn_avatar = "!avatar({})".format(self.players[self.turn])
+            self.broadcast('{} It\'s **{}**\'s ({}) turn.'.format(
+                user_turn_avatar,
                 self.gameAdapter.get_username_by_email(
                     self.players[self.turn]),
                 self.gameAdapter.gameMessageHandler.get_player_color(self.turn)))
@@ -809,7 +815,9 @@ class GameInstance(object):
                 game_over = self.players[self.turn]
             self.end_game(game_over)
             return
-        self.current_messages.append('It\'s @**{}**\'s ({}) turn.'.format(
+        user_turn_avatar = "!avatar({})".format(self.players[self.turn])
+        self.current_messages.append('{} It\'s **{}**\'s ({}) turn.'.format(
+            user_turn_avatar,
             self.gameAdapter.get_username_by_email(self.players[self.turn]),
             self.gameAdapter.gameMessageHandler.get_player_color(self.turn)
         ))
@@ -821,7 +829,9 @@ class GameInstance(object):
         self.turn += 1
         if self.turn >= len(self.players):
             self.turn = 0
-        self.current_messages.append('It\'s @**{}**\'s ({}) turn.'.format(
+        user_turn_avatar = "!avatar({})".format(self.players[self.turn])
+        self.current_messages.append('{} It\'s **{}**\'s ({}) turn.'.format(
+            user_turn_avatar,
             self.gameAdapter.get_username_by_email(self.players[self.turn]),
             self.gameAdapter.gameMessageHandler.get_player_color(self.turn)
         ))
@@ -844,7 +854,9 @@ class GameInstance(object):
         elif winner.startswith('except:'):
             loser = winner.lstrip('except:')
         else:
-            self.broadcast('{} won! :tada:'.format(winner))
+            winner_avatar = "!avatar({})".format(winner)
+            winner_name = self.gameAdapter.get_username_by_email(winner)
+            self.broadcast('{} **{}** won! :tada:'.format(winner_avatar, winner_name))
         for u in self.players:
             values = {'total_games': 1, 'games_won': 0,
                       'games_lost': 0, 'games_drawn': 0}


### PR DESCRIPTION
The cases I've seen & replaced the occurrence of user email with user avatar are:

* when a player wins,

![win](https://user-images.githubusercontent.com/25483260/37478229-a8eefe30-289f-11e8-9676-8b6772690e69.png)

* when a player quits the game, and

![quit](https://user-images.githubusercontent.com/25483260/37478665-de4bb144-28a0-11e8-99f0-22ea8db00aba.png)

* when a player joins the game.

![join](https://user-images.githubusercontent.com/25483260/37461423-585bd1bc-2874-11e8-8d67-138240caf9a2.png)

* telling a user about his turn

![turn](https://user-images.githubusercontent.com/25483260/37478301-d5bee9de-289f-11e8-9993-95e284c57026.png)

Please let me know if I've missed any case...