### PR TITLE
[WIP]Allow bots to upload files.

### DIFF
--- a/zulip_bots/zulip_bots/custom_exceptions.py
+++ b/zulip_bots/zulip_bots/custom_exceptions.py
@@ -9,3 +9,11 @@ class ConfigValidationError(Exception):
     Raise if the config data passed to a bot's validate_config()
     is invalid (e.g. wrong API key, invalid email, etc.).
     '''
+
+class FileUploadError(Exception):
+    '''
+    Raise if the file upload to a Zulip server fails.
+    '''
+    def __init__(self, msg, payload):
+        super(FileUploadError, self).__init__(msg)
+        self.payload = payload  # the complete dict from the upload_file method.

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -158,6 +158,24 @@ class ExternalBotHandler(object):
         else:
             self._rate_limit.show_error_and_exit()
 
+    def upload_file(self, file):
+        # type: (IO[Any]) -> Dict[str, Any]
+        if self._rate_limit.is_legal():
+            return self._client.upload_file(file)
+        else:
+            self._rate_limit.show_error_and_exit()
+
+    def upload_file_from_path(self, file_path):
+        # type: (str) -> Dict[str, Any]
+        try:
+            abs_filepath = os.path.abspath(file_path)
+            with open(abs_filepath, 'rb') as file:
+                return self.upload_file(file)
+        except OSError:
+            # Print the path that the code is trying to open.
+            logging.error('Error opening the file at {}'.format(abs_filepath))
+            raise
+
     def get_config_info(self, bot_name, optional=False):
         # type: (str, Optional[bool]) -> Dict[str, Any]
 


### PR DESCRIPTION
This commit exposes the already existing method in
Zulip Client to upload files.

Fixes #351 