### PR TITLE
Automatically add a bot handler's parent dir to the python path.

### DIFF
--- a/zulip_bots/zulip_bots/run.py
+++ b/zulip_bots/zulip_bots/run.py
@@ -112,10 +112,13 @@ def main():
     args = parse_args()
     if os.path.isfile(args.bot):
         bot_path = os.path.abspath(args.bot)
+        bot_dir = os.path.dirname(bot_path)
         bot_name = os.path.splitext(basename(bot_path))[0]
     else:
         bot_path = os.path.abspath(os.path.join(current_dir, 'bots', args.bot, args.bot+'.py'))
+        bot_dir = os.path.dirname(bot_path)
         bot_name = args.bot
+    sys.path.insert(0, bot_dir)
     if args.provision:
         provision_bot(os.path.dirname(bot_path), args.force)
 

--- a/zulip_bots/zulip_bots/test_run.py
+++ b/zulip_bots/zulip_bots/test_run.py
@@ -14,6 +14,7 @@ from unittest import TestCase
 
 from unittest import mock
 from unittest.mock import patch
+import sys
 
 class TestDefaultArguments(TestCase):
 
@@ -46,6 +47,15 @@ class TestDefaultArguments(TestCase):
             bot_config_file=None,
             lib_module=mock.ANY,
             quiet=False)
+
+    @patch('sys.argv', ['zulip-run-bot', path_to_bot, '--config-file', '/foo/bar/baz.conf'])
+    @patch('zulip_bots.run.run_message_handler_for_bot')
+    def test_module_import(self, mock_run_message_handler_for_bot):
+        # type: (mock.Mock) -> None
+        path_to_bots_dir = os.path.dirname(os.path.dirname(self.path_to_bot))
+        sys.path.insert(0, path_to_bots_dir)
+        import helloworld
+        self.assertIn(path_to_bots_dir, sys.path)
 
 class TestBotLib(TestCase):
     def test_extract_query_without_mention(self):


### PR DESCRIPTION
Fixes: #356 

I tested this in two ways:
1. Copied `helloworld` bot outside `python-zulip-api` in my local repo. Created one module in helloworld directory and imported in `helloworld.py`.
ran the bot using `zulip-run-bot path_to_helloworld.py -c path_to_zuliprc`
2. For the helloworld bot residing in zulip repository, created a module in helloworld directory and imported in `helloworld.py`.
ran the bot using `zulip-run-bot helloworld -c path_to_zuliprc`
This also makes it possible to import modules in subdirectories.