### PR TITLE
API: Use `session.headers.update` method to add user-agent header.

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -414,7 +414,7 @@ class Client(object):
         session.auth = requests.auth.HTTPBasicAuth(self.email, self.api_key)
         session.verify = self.tls_verification  # type: ignore # https://github.com/python/typeshed/pull/1504
         session.cert = client_cert
-        session.headers = {"User-agent": self.get_user_agent()}
+        session.headers.update({"User-agent": self.get_user_agent()})
         self.session = session
 
     def get_user_agent(self):


### PR DESCRIPTION
Directly assigning session.headers overrides the default header
paramers and removes `{'Accept-Encoding': 'gzip, deflate'}` from
the headers.