### PR TITLE
Mypy.ini migration & simplification

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,7 @@
 check_untyped_defs = True
 disallow_any_generics = True
 strict_optional = True
+no_implicit_optional = True
 
 incremental = True
 scripts_are_modules = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 check_untyped_defs = True
 disallow_any_generics = True
+strict_optional = True
 
 incremental = True
 scripts_are_modules = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+check_untyped_defs = True
+disallow_any_generics = True
+
+incremental = True
+scripts_are_modules = True
+show_traceback = True
+
+warn_no_return = True

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -149,11 +149,7 @@ for file_path in python_files:
 
 mypy_command = "mypy"
 
-extra_args = ["--check-untyped-defs",
-              "--follow-imports=silent",
-              "--scripts-are-modules",
-              "--disallow-any-generics",
-              "-i"]
+extra_args = ["--follow-imports=silent"]
 if args.disallow_untyped_defs:
     extra_args.append("--disallow-untyped-defs")
 if args.warn_unused_ignores:

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -110,8 +110,6 @@ parser.add_argument('--no-disallow-untyped-defs', dest='disallow_untyped_defs', 
                     help="""Don't throw errors when functions are not annotated""")
 parser.add_argument('--scripts-only', dest='scripts_only', action='store_true', default=False,
                     help="""Only type check extensionless python scripts""")
-parser.add_argument('--no-strict-optional', dest='strict_optional', action='store_false', default=True,
-                    help="""Don't use the --strict-optional flag with mypy""")
 parser.add_argument('--warn-unused-ignores', dest='warn_unused_ignores', action='store_true', default=False,
                     help="""Use the --warn-unused-ignores flag with mypy""")
 parser.add_argument('--no-ignore-missing-imports', dest='ignore_missing_imports', action='store_false', default=True,
@@ -154,8 +152,6 @@ if args.disallow_untyped_defs:
     extra_args.append("--disallow-untyped-defs")
 if args.warn_unused_ignores:
     extra_args.append("--warn-unused-ignores")
-if args.strict_optional:
-    extra_args.append("--strict-optional")
 if args.ignore_missing_imports:
     extra_args.append("--ignore-missing-imports")
 if args.quick:

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -286,7 +286,7 @@ class Client(object):
                  site=None, client=None,
                  cert_bundle=None, insecure=None,
                  client_cert=None, client_cert_key=None):
-        # type: (Optional[str], Optional[str], Optional[str], bool, bool, Optional[str], Optional[str], Optional[str], bool, Optional[str], Optional[str]) -> None
+        # type: (Optional[str], Optional[str], Optional[str], bool, bool, Optional[str], Optional[str], Optional[str], Optional[bool], Optional[str], Optional[str]) -> None
         if client is None:
             client = _default_client()
 

--- a/zulip_bots/zulip_bots/bots/idonethis/idonethis.py
+++ b/zulip_bots/zulip_bots/bots/idonethis/idonethis.py
@@ -3,7 +3,7 @@ import requests
 import logging
 import re
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 API_BASE_URL = "https://beta.idonethis.com/api/v2"
 
@@ -25,7 +25,7 @@ class UnknownCommandSyntax(Exception):
 class UnspecifiedProblemException(Exception):
     pass
 
-def make_API_request(endpoint: str, method: str="GET", body: Dict[str, str]=None) -> Any:
+def make_API_request(endpoint: str, method: str="GET", body: Optional[Dict[str, str]]=None) -> Any:
     headers = {'Authorization': 'Token ' + api_key}
     if method == "GET":
         r = requests.get(API_BASE_URL + endpoint, headers=headers)
@@ -52,7 +52,7 @@ def api_show_team(hash_id: str) -> Any:
 def api_show_users(hash_id: str) -> Any:
     return make_API_request("/teams/{}/members".format(hash_id))
 
-def api_list_entries(team_id: str=None) -> Any:
+def api_list_entries(team_id: Optional[str]=None) -> Any:
     if team_id:
         return make_API_request("/entries?team_id={}".format(team_id))
     else:

--- a/zulip_bots/zulip_bots/bots/xkcd/xkcd.py
+++ b/zulip_bots/zulip_bots/bots/xkcd/xkcd.py
@@ -3,7 +3,7 @@ import random
 import logging
 import requests
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 XKCD_TEMPLATE_URL = 'https://xkcd.com/%s/info.0.json'
 LATEST_XKCD_URL = 'https://xkcd.com/info.0.json'
@@ -84,7 +84,7 @@ def get_xkcd_bot_response(message: Dict[str, str]) -> str:
                                            fetched['alt'],
                                            fetched['img']))
 
-def fetch_xkcd_query(mode: int, comic_id: str = None) -> Dict[str, str]:
+def fetch_xkcd_query(mode: int, comic_id: Optional[str]=None) -> Dict[str, str]:
     try:
         if mode == XkcdBotCommand.LATEST:  # Fetch the latest comic strip.
             url = LATEST_XKCD_URL

--- a/zulip_bots/zulip_bots/bots/yoda/test_yoda.py
+++ b/zulip_bots/zulip_bots/bots/yoda/test_yoda.py
@@ -1,6 +1,8 @@
 from zulip_bots.bots.yoda.yoda import ServiceUnavailableError
 from zulip_bots.test_lib import BotTestCase
 
+from typing import Optional
+
 class TestYodaBot(BotTestCase):
     bot_name = "yoda"
 
@@ -18,7 +20,7 @@ class TestYodaBot(BotTestCase):
             @mention-bot You will learn how to speak like me someday.
             '''
 
-    def _test(self, message: str, response: str, fixture: str=None) -> None:
+    def _test(self, message: str, response: str, fixture: Optional[str]=None) -> None:
         with self.mock_config_info({'api_key': '12345678'}):
             if fixture is not None:
                 with self.mock_http_conversation(fixture):


### PR DESCRIPTION
There have been a few changes In the main Zulip repo, which feel reasonable to replicate here:
* migration to use a `mypy.ini` file, allowing finer-grained control of settings applying to different files;
* removal of the strict-optional setting - it's on by default (and can be controlled per-file in mypy.ini);
* addition of `warn_no_return` and `no_implicit_optional` settings for further strictness.

The latter setting requires some annotation changes and affects situations such as:
```python
def f(x: str=None) -> None:
   ...
```
These pass without this latter setting; now a more explicit `Optional[str]` is necessary, as might be expected.

The mypy.ini commit has a line which shows tracebacks on fatal error, and is included in the main repo; should we include it here?