### PR TITLE
zulip: Amend default value of remove_subscriptions:principals to None.

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -816,11 +816,14 @@ class Client(object):
             request=request,
         )
 
-    def remove_subscriptions(self, streams, principals=[]):
+    def remove_subscriptions(self, streams, principals=None):
         # type: (Iterable[str], Optional[Iterable[str]]) -> Dict[str, Any]
         '''
             See examples/unsubscribe for example usage.
         '''
+        if principals is None:
+            principals = []
+
         request = dict(
             subscriptions=streams,
             principals=principals


### PR DESCRIPTION
Having a default parameter as '[]' may not be an issue with the current implementation, but general practice is to default to None and assign a default list subsequently.