### PR TITLE
tools/deploy : Add logs endpoint to receive logs for the specified bot.

### DIFF
--- a/tools/deploy
+++ b/tools/deploy
@@ -146,6 +146,25 @@ def prepare(options: argparse.Namespace) -> None:
     clean(options)
     process(options)
 
+def log(options: argparse.Namespace) -> None:
+    check_common_options(options)
+    headers = {'key': options.key}
+    if options.lines:
+        lines = options.lines
+    else:
+        lines = None
+    payload = {'name': options.botname, 'lines': lines}
+    url = urllib.parse.urljoin(options.server, 'bots/logs/' + options.botname)
+    r = requests.get(url, json=payload, headers=headers)
+    if r.status_code == requests.codes.ok:
+        print(r.text)
+        return
+    if r.status_code == 401:
+        print('log: Authentication error with the server. Aborting.')
+    else:
+        print('log: Error {}: {}. Aborting.'.format(r.status_code, r.text))
+    sys.exit(1)
+
 def main() -> None:
     usage = """tools/deploy <command> <bot-name> [options]
 
@@ -165,6 +184,9 @@ To stop the bot, use:
 
     tools/deploy stop mybot --server=$SERVER --key=$TOKEN
 
+To get logs of the bot, use:
+    tools/deploy log mybot --serverr=$SERVER --key=$TOKEN
+
 """
     parser = argparse.ArgumentParser(usage=usage)
     parser.add_argument('command', help='Command to run.')
@@ -181,6 +203,8 @@ To stop the bot, use:
                         help='Path to the zuliprc file.')
     parser.add_argument('--main', '-m',
                         help='Path to the bot\'s main file, relative to the bot\'s directory.')
+    parser.add_argument('--lines', '-l',
+                        help='Number of lines in log required.')
     options = parser.parse_args()
     if not options.command:
         print('tools/deploy: No command specified.')
@@ -197,6 +221,7 @@ To stop the bot, use:
         'process': process,
         'start': start,
         'stop': stop,
+        'log': log,
     }
     if options.command in commands:
         commands[options.command](options)

--- a/tools/deploy
+++ b/tools/deploy
@@ -72,7 +72,8 @@ def upload(options: argparse.Namespace) -> None:
     check_common_options(options)
     file_path = os.path.join(bots_dir, options.botname + '.zip')
     if not os.path.exists(file_path):
-        print('upload: Could not find bot package at {}.'.format(file_path))
+        print('During execution of function upload in tools/deploy.py, the following error was encountered:\n'
+              'Could not find bot package at {}.'.format(file_path))
         sys.exit(1)
     files = {'file': open(file_path, 'rb')}
     headers = {'key': options.key}
@@ -82,9 +83,11 @@ def upload(options: argparse.Namespace) -> None:
         print('upload: Uploaded the bot package to botfarm.')
         return
     if r.status_code == 401:
-        print('upload: Authentication error with the server. Aborting.')
+        print('During execution of function upload in tools/deploy.py, the following error was encountered:\n'
+              'Authentication error with the server. Aborting.')
     else:
-        print('upload: Error {}. Aborting.'.format(r.status_code))
+        print('During execution of function upload in tools/deploy.py, the following error was encountered:\n'
+              'Error {}. Aborting.'.format(r.status_code))
     sys.exit(1)
 
 def clean(options: argparse.Namespace) -> None:
@@ -93,7 +96,8 @@ def clean(options: argparse.Namespace) -> None:
         os.remove(file_path)
         print('clean: Removed {}.'.format(file_path))
     else:
-        print('clean: File \'{}\' not found.'.format(file_path))
+        print('During execution of function clean in tools/deploy.py, the following error was encountered:\n'
+              'File \'{}\' not found.'.format(file_path))
 
 def process(options: argparse.Namespace) -> None:
     check_common_options(options)
@@ -105,9 +109,11 @@ def process(options: argparse.Namespace) -> None:
         print('process: The bot has been processed by the botfarm.')
         return
     if r.status_code == 401:
-        print('process: Authentication error with the server. Aborting.')
+        print('During execution of function process in tools/deploy.py, the following error was encountered:\n'
+              'Authentication error with the server. Aborting.')
     else:
-        print('process: Error {}: {}. Aborting.'.format(r.status_code, r.text))
+        print('During execution of function process in tools/deploy.py, the following error was encountered:\n'
+              'Error {}: {}. Aborting.'.format(r.status_code, r.text))
     sys.exit(1)
 
 def start(options: argparse.Namespace) -> None:
@@ -120,9 +126,11 @@ def start(options: argparse.Namespace) -> None:
         print('start: The bot has been started by the botfarm.')
         return
     if r.status_code == 401:
-        print('start: Authentication error with the server. Aborting.')
+        print('During execution of function start in tools/deploy.py, the following error was encountered:\n'
+              'Authentication error with the server. Aborting.')
     else:
-        print('start: Error {}: {}. Aborting.'.format(r.status_code, r.text))
+        print('During execution of function start in tools/deploy.py, the following error was encountered:\n'
+              'Error {}: {}. Aborting.'.format(r.status_code, r.text))
     sys.exit(1)
 
 def stop(options: argparse.Namespace) -> None:
@@ -135,9 +143,11 @@ def stop(options: argparse.Namespace) -> None:
         print('stop: The bot has been stopped by the botfarm.')
         return
     if r.status_code == 401:
-        print('stop: Authentication error with the server. Aborting.')
+        print('During execution of function stop in tools/deploy.py, the following error was encountered:\n'
+              'Authentication error with the server. Aborting.')
     else:
-        print('stop: Error {}: {}. Aborting.'.format(r.status_code, r.text))
+        print('During execution of function stop in tools/deploy.py, the following error was encountered:\n'
+              'Error {}: {}. Aborting.'.format(r.status_code, r.text))
     sys.exit(1)
 
 def prepare(options: argparse.Namespace) -> None:
@@ -160,9 +170,11 @@ def log(options: argparse.Namespace) -> None:
         print(r.text)
         return
     if r.status_code == 401:
-        print('log: Authentication error with the server. Aborting.')
+        print('During execution of function log in tools/deploy.py, the following error was encountered:\n'
+              'Authentication error with the server. Aborting.')
     else:
-        print('log: Error {}: {}. Aborting.'.format(r.status_code, r.text))
+        print('During execution of function log in tools/deploy.py, the following error was encountered:\n'
+              'Error {}: {}. Aborting.'.format(r.status_code, r.text))
     sys.exit(1)
 
 def main() -> None:


### PR DESCRIPTION
Fixes one of the tasks listed in [338](https://github.com/zulip/python-zulip-api/issues/338)
Steps to run:
1. Assuming a bot is running on the botfarm with name helloworld. (check [337](https://github.com/zulip/python-zulip-api/pull/337) for more details.)
2. Run the command `tools/deploy -s $SERVER -k $KEY log helloworld`
Sample Traceback:
```
Running Helloworld Bot:

        This is a boilerplate bot that responds to a user query with
        "beep boop", which is robot for "Hello World".

        This bot can be used as a template for other, more
        sophisticated, bots.
        
INFO:root:starting message handling...

```
4. To get top n number of lines as response, run the following command:
`tools/deploy -s $SERVER -k $KEY log helloworld --lines 4`
Sample Traceback:
```
Running Helloworld Bot:

        This is a boilerplate bot that responds to a user query with
        "beep boop", which is robot for "Hello World".

```
