### PR TITLE
Bots: Support run-time bot identity (update of #47)

### DIFF
--- a/zulip_bots/zulip_bots/bots/wikipedia/test_wikipedia.py
+++ b/zulip_bots/zulip_bots/bots/wikipedia/test_wikipedia.py
@@ -52,7 +52,7 @@ class TestWikipediaBot(BotTestCase):
 
         # Empty query, no request made to the Internet.
         bot_request = ''
-        bot_response = "Please enter your search term after @mention-bot"
+        bot_response = "Please enter your search term after @**test-bot**"
         self.verify_reply(bot_request, bot_response)
 
         # Incorrect status code

--- a/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
+++ b/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
@@ -40,12 +40,12 @@ class WikipediaHandler(object):
     def get_bot_wiki_response(self, message: Dict[str, str], bot_handler: Any) -> Optional[str]:
         '''This function returns the URLs of the requested topic.'''
 
-        help_text = 'Please enter your search term after @mention-bot'
+        help_text = 'Please enter your search term after {}'
 
         # Checking if the link exists.
         query = message['content']
         if query == '':
-            return help_text
+            return help_text.format(bot_handler.identity().mention)
 
         query_wiki_url = 'https://en.wikipedia.org/w/api.php'
         query_wiki_params = dict(

--- a/zulip_bots/zulip_bots/bots/xkcd/test_xkcd.py
+++ b/zulip_bots/zulip_bots/bots/xkcd/test_xkcd.py
@@ -44,10 +44,11 @@ class TestXkcdBot(BotTestCase):
         help_txt = "xkcd bot supports these commands:"
         err_txt  = "xkcd bot only supports these commands, not `{}`:"
         commands = '''
-* `@xkcd help` to show this help message.
-* `@xkcd latest` to fetch the latest comic strip from xkcd.
-* `@xkcd random` to fetch a random comic strip from xkcd.
-* `@xkcd <comic id>` to fetch a comic strip based on `<comic id>` e.g `@xkcd 1234`.'''
+* `{0} help` to show this help message.
+* `{0} latest` to fetch the latest comic strip from xkcd.
+* `{0} random` to fetch a random comic strip from xkcd.
+* `{0} <comic id>` to fetch a comic strip based on `<comic id>` e.g `{0} 1234`.'''.format(
+            "@**test-bot**")
         self.verify_reply('', err_txt.format('') + commands)
         self.verify_reply('help', help_txt + commands)
         # Example invalid command

--- a/zulip_bots/zulip_bots/bots/xkcd/xkcd.py
+++ b/zulip_bots/zulip_bots/bots/xkcd/xkcd.py
@@ -35,7 +35,8 @@ class XkcdHandler(object):
             '''
 
     def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
-        xkcd_bot_response = get_xkcd_bot_response(message)
+        quoted_name = bot_handler.identity().mention
+        xkcd_bot_response = get_xkcd_bot_response(message, quoted_name)
         bot_handler.send_reply(message, xkcd_bot_response)
 
 class XkcdBotCommand(object):
@@ -49,16 +50,16 @@ class XkcdNotFoundError(Exception):
 class XkcdServerError(Exception):
     pass
 
-def get_xkcd_bot_response(message: Dict[str, str]) -> str:
+def get_xkcd_bot_response(message: Dict[str, str], quoted_name: str) -> str:
     original_content = message['content'].strip()
     command = original_content.strip()
 
     commands_help = ("%s"
-                     "\n* `@xkcd help` to show this help message."
-                     "\n* `@xkcd latest` to fetch the latest comic strip from xkcd."
-                     "\n* `@xkcd random` to fetch a random comic strip from xkcd."
-                     "\n* `@xkcd <comic id>` to fetch a comic strip based on `<comic id>` "
-                     "e.g `@xkcd 1234`.")
+                     "\n* `{0} help` to show this help message."
+                     "\n* `{0} latest` to fetch the latest comic strip from xkcd."
+                     "\n* `{0} random` to fetch a random comic strip from xkcd."
+                     "\n* `{0} <comic id>` to fetch a comic strip based on `<comic id>` "
+                     "e.g `{0} 1234`.".format(quoted_name))
 
     try:
         if command == 'help':

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -80,6 +80,11 @@ class StateHandler(object):
     def contains(self, key: Text) -> bool:
         return key in self.state_
 
+class BotIdentity(object):
+    def __init__(self, name: str, email: str) -> None:
+        self.name = name
+        self.email = email
+        self.mention = '@**' + name + '**'
 
 class ExternalBotHandler(object):
     def __init__(
@@ -128,6 +133,9 @@ class ExternalBotHandler(object):
     @property
     def storage(self) -> StateHandler:
         return self._storage
+
+    def identity(self) -> BotIdentity:
+        return BotIdentity(self.full_name, self.email)
 
     def send_message(self, message: (Dict[str, Any])) -> Dict[str, Any]:
         if not self._rate_limit.is_legal():

--- a/zulip_bots/zulip_bots/simple_lib.py
+++ b/zulip_bots/zulip_bots/simple_lib.py
@@ -1,6 +1,8 @@
 import configparser
 import sys
 
+from zulip_bots.lib import BotIdentity
+
 class SimpleStorage:
     def __init__(self):
         self.data = dict()
@@ -35,6 +37,9 @@ class TerminalBotHandler:
         self.bot_config_file = bot_config_file
         self.storage = SimpleStorage()
         self.message_server = SimpleMessageServer()
+
+    def identity(self):
+        return BotIdentity("bot name", "bot-email@domain")
 
     def send_message(self, message):
         if message['type'] == 'stream':

--- a/zulip_bots/zulip_bots/test_lib.py
+++ b/zulip_bots/zulip_bots/test_lib.py
@@ -21,6 +21,7 @@ from zulip_bots.test_file_utils import (
     read_bot_fixture_data,
 )
 
+from zulip_bots.lib import BotIdentity
 
 class StubBotHandler:
     def __init__(self) -> None:
@@ -32,6 +33,9 @@ class StubBotHandler:
 
     def reset_transcript(self) -> None:
         self.transcript = []  # type: List[Tuple[str, Dict[str, Any]]]
+
+    def identity(self) -> BotIdentity:
+        return BotIdentity(self.full_name, self.email)
 
     def send_message(self, message: Dict[str, Any]) -> Dict[str, Any]:
         self.transcript.append(('send_message', message))


### PR DESCRIPTION
This PR is an update of #47.

Main changes:
* refactored against current master & changes since original PR;
* splitting/merging commits to more logical order;
* namedtuple -> class for BotIdentity, as quoted_name/mention is calculable;
* moved to `mention` from `quoted_name`, as former is simpler.

Feedback sought:
* Where should BotIdentity go? The current imports in `simple_lib.py` and `test_lib.py` seem off?;
* Should more bots be updated as part of this PR, or are two sufficient for examples?