### PR TITLE
#356 Automatically add a bot handler's parent dir to the python path 

### DIFF
--- a/zulip_bots/zulip_bots/run.py
+++ b/zulip_bots/zulip_bots/run.py
@@ -116,6 +116,7 @@ def main():
     else:
         bot_path = os.path.abspath(os.path.join(current_dir, 'bots', args.bot, args.bot+'.py'))
         bot_name = args.bot
+    sys.path.insert(0, os.path.dirname(bot_path))
     if args.provision:
         provision_bot(os.path.dirname(bot_path), args.force)
 

--- a/zulip_bots/zulip_bots/test_run.py
+++ b/zulip_bots/zulip_bots/test_run.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 import importlib
 import os
+import sys
 import zulip_bots.run
 from zulip_bots.lib import extract_query_without_mention
 import unittest
@@ -46,6 +47,33 @@ class TestDefaultArguments(TestCase):
             bot_config_file=None,
             lib_module=mock.ANY,
             quiet=False)
+
+    def test_adding_bot_parent_dir_to_sys_path_when_bot_name_specified(self):
+        # type: () -> None
+        bot_name = 'any_bot_name'
+        expected_bot_dir_path = os.path.join(
+            os.path.dirname(zulip_bots.run.__file__),
+            'bots',
+            bot_name
+        )
+        self._test_adding_bot_parent_dir_to_sys_path(bot_qualifier=bot_name, bot_dir_path=expected_bot_dir_path)
+
+    @patch('os.path.isfile', return_value=True)
+    def test_adding_bot_parent_dir_to_sys_path_when_bot_path_specified(self, mock_os_path_isfile):
+        # type: (mock.Mock) -> None
+        bot_path = '/path/to/bot'
+        expected_bot_dir_path = '/path/to'
+        self._test_adding_bot_parent_dir_to_sys_path(bot_qualifier=bot_path, bot_dir_path=expected_bot_dir_path)
+
+    def _test_adding_bot_parent_dir_to_sys_path(self, bot_qualifier, bot_dir_path):
+        # type: (str, str) -> None
+        with patch('sys.argv', ['zulip-run-bot', bot_qualifier, '--config-file', '/path/to/config']):
+            with patch('zulip_bots.run.import_module_from_source', return_value=mock.Mock()):
+                with patch('zulip_bots.run.run_message_handler_for_bot'):
+                    with patch('zulip_bots.run.exit_gracefully_if_zulip_config_file_does_not_exist'):
+                        zulip_bots.run.main()
+
+        self.assertIn(bot_dir_path, sys.path)
 
 class TestBotLib(TestCase):
     def test_extract_query_without_mention(self):


### PR DESCRIPTION
Fixes #356.