### PR TITLE
#6 bots: Encode URLs properly to outbound sites.

### DIFF
--- a/zulip_bots/zulip_bots/bots/idonethis/fixtures/api_noop.json
+++ b/zulip_bots/zulip_bots/bots/idonethis/fixtures/api_noop.json
@@ -3,7 +3,8 @@
     "api_url": "https://beta.idonethis.com/api/v2/noop",
     "headers": {
         "Authorization": "Token 12345678"
-    }
+    },
+    "params": null
   },
   "response": {"doesnt": "matter"},
   "response-headers": {

--- a/zulip_bots/zulip_bots/bots/idonethis/fixtures/team_list.json
+++ b/zulip_bots/zulip_bots/bots/idonethis/fixtures/team_list.json
@@ -3,7 +3,8 @@
     "api_url": "https://beta.idonethis.com/api/v2/teams",
     "headers": {
         "Authorization": "Token 12345678"
-    }
+    },
+    "params": null
   },
   "response": [
     {

--- a/zulip_bots/zulip_bots/bots/idonethis/fixtures/test_401.json
+++ b/zulip_bots/zulip_bots/bots/idonethis/fixtures/test_401.json
@@ -3,7 +3,8 @@
     "api_url": "https://beta.idonethis.com/api/v2/teams",
     "headers": {
         "Authorization": "Token 87654321"
-    }
+    },
+    "params": null
   },
   "response": {
     "error": "Invalid API Authentication"

--- a/zulip_bots/zulip_bots/bots/idonethis/fixtures/test_create_entry.json
+++ b/zulip_bots/zulip_bots/bots/idonethis/fixtures/test_create_entry.json
@@ -8,7 +8,8 @@
     },
     "headers": {
         "Authorization": "Token 12345678"
-    }
+    },
+    "params": null
   },
   "response": {
     "body": "something and something else",

--- a/zulip_bots/zulip_bots/bots/idonethis/fixtures/test_create_entry_team_2.json
+++ b/zulip_bots/zulip_bots/bots/idonethis/fixtures/test_create_entry_team_2.json
@@ -8,7 +8,8 @@
     },
     "headers": {
         "Authorization": "Token 12345678"
-    }
+    },
+    "params": null
   },
   "response": {
     "body": "something and something else",

--- a/zulip_bots/zulip_bots/bots/idonethis/fixtures/test_entries_list.json
+++ b/zulip_bots/zulip_bots/bots/idonethis/fixtures/test_entries_list.json
@@ -1,8 +1,11 @@
 {
   "request": {
-    "api_url": "https://beta.idonethis.com/api/v2/entries?team_id=31415926535",
+    "api_url": "https://beta.idonethis.com/api/v2/entries",
     "headers": {
         "Authorization": "Token 12345678"
+    },
+    "params": {
+      "team_id": "31415926535"
     }
   },
   "response": [

--- a/zulip_bots/zulip_bots/bots/idonethis/fixtures/test_show_team.json
+++ b/zulip_bots/zulip_bots/bots/idonethis/fixtures/test_show_team.json
@@ -3,7 +3,8 @@
     "api_url": "https://beta.idonethis.com/api/v2/teams/31415926535",
     "headers": {
         "Authorization": "Token 12345678"
-    }
+    },
+    "params": null
   },
   "response": {
     "hash_id": "31415926535",

--- a/zulip_bots/zulip_bots/bots/idonethis/idonethis.py
+++ b/zulip_bots/zulip_bots/bots/idonethis/idonethis.py
@@ -25,12 +25,15 @@ class UnknownCommandSyntax(Exception):
 class UnspecifiedProblemException(Exception):
     pass
 
-def make_API_request(endpoint: str, method: str="GET", body: Optional[Dict[str, str]]=None) -> Any:
+def make_API_request(endpoint: str,
+                     method: str="GET",
+                     body: Optional[Dict[str, str]]=None,
+                     params: Optional[Dict[str, str]]=None) -> Any:
     headers = {'Authorization': 'Token ' + api_key}
     if method == "GET":
-        r = requests.get(API_BASE_URL + endpoint, headers=headers)
+        r = requests.get(API_BASE_URL + endpoint, headers=headers, params=params)
     elif method == "POST":
-        r = requests.post(API_BASE_URL + endpoint, headers=headers, json=body)
+        r = requests.post(API_BASE_URL + endpoint, headers=headers, params=params, json=body)
     if r.status_code == 200:
         return r.json()
     elif r.status_code == 401 and 'error' in r.json() and r.json()['error']  == "Invalid API Authentication":
@@ -54,9 +57,9 @@ def api_show_users(hash_id: str) -> Any:
 
 def api_list_entries(team_id: Optional[str]=None) -> Any:
     if team_id:
-        return make_API_request("/entries?team_id={}".format(team_id))
+        return make_API_request("/entries", params=dict(team_id=team_id))
     else:
-        return make_API_request("/entries".format(team_id))
+        return make_API_request("/entries")
 
 def api_create_entry(body: str, team_id: str) -> Any:
     return make_API_request("/entries", "POST", {"body": body, "team_id": team_id})

--- a/zulip_bots/zulip_bots/bots/link_shortener/link_shortener.py
+++ b/zulip_bots/zulip_bots/bots/link_shortener/link_shortener.py
@@ -35,8 +35,8 @@ class LinkShortenerHandler(object):
             '('
             '(?:http|https):\/\/'  # This allows for the HTTP or HTTPS
                                    # protocol.
-            '[^"<>#%\{\}|\\^~[\]` ]+'  # This allows for any character except
-                                       # for certain non-URL-safe ones.
+            '[^"<>\{\}|\\^~[\]` ]+'  # This allows for any character except
+                                     # for certain non-URL-safe ones.
             ')'
         )
 

--- a/zulip_bots/zulip_bots/bots/stack_overflow/fixtures/test_incorrect_query.json
+++ b/zulip_bots/zulip_bots/bots/stack_overflow/fixtures/test_incorrect_query.json
@@ -1,6 +1,12 @@
 {
     "request": {
-        "api_url":"http://api.stackexchange.com/2.2/search/advanced?order=desc&sort=relevance&site=stackoverflow&title=narendra"
+        "api_url":"http://api.stackexchange.com/2.2/search/advanced",
+        "params": {
+            "order": "desc",
+            "sort": "relevance",
+            "site": "stackoverflow",
+            "title": "narendra"
+        }
     },
     "response": {
         "data": {

--- a/zulip_bots/zulip_bots/bots/stack_overflow/fixtures/test_multi_word.json
+++ b/zulip_bots/zulip_bots/bots/stack_overflow/fixtures/test_multi_word.json
@@ -1,6 +1,12 @@
 {
     "request": {
-        "api_url":"http://api.stackexchange.com/2.2/search/advanced?order=desc&sort=relevance&site=stackoverflow&title=what%20is%20flutter"
+        "api_url":"http://api.stackexchange.com/2.2/search/advanced",
+        "params": {
+            "order": "desc",
+            "sort": "relevance",
+            "site": "stackoverflow",
+            "title": "what is flutter"
+        }
     },
     "response": {
         "data": {

--- a/zulip_bots/zulip_bots/bots/stack_overflow/fixtures/test_number_query.json
+++ b/zulip_bots/zulip_bots/bots/stack_overflow/fixtures/test_number_query.json
@@ -1,6 +1,12 @@
 {
     "request": {
-        "api_url":"http://api.stackexchange.com/2.2/search/advanced?order=desc&sort=relevance&site=stackoverflow&title=113"
+        "api_url":"http://api.stackexchange.com/2.2/search/advanced",
+        "params": {
+            "order": "desc",
+            "sort": "relevance",
+            "site": "stackoverflow",
+            "title": "113"
+        }
     },
     "response": {
         "data": {

--- a/zulip_bots/zulip_bots/bots/stack_overflow/fixtures/test_single_word.json
+++ b/zulip_bots/zulip_bots/bots/stack_overflow/fixtures/test_single_word.json
@@ -1,6 +1,12 @@
 {
     "request": {
-        "api_url":"http://api.stackexchange.com/2.2/search/advanced?order=desc&sort=relevance&site=stackoverflow&title=restful"
+        "api_url":"http://api.stackexchange.com/2.2/search/advanced",
+        "params": {
+            "order": "desc",
+            "sort": "relevance",
+            "site": "stackoverflow",
+            "title": "restful"
+        }
     },
     "response": {
         "data": {

--- a/zulip_bots/zulip_bots/bots/stack_overflow/fixtures/test_status_code.json
+++ b/zulip_bots/zulip_bots/bots/stack_overflow/fixtures/test_status_code.json
@@ -1,6 +1,12 @@
 {
     "request": {
-        "api_url":"http://api.stackexchange.com/2.2/search/advanced?order=desc&sort=relevance&site=stackoverflow&title=Zulip"
+        "api_url":"http://api.stackexchange.com/2.2/search/advanced",
+        "params": {
+            "order": "desc",
+            "sort": "relevance",
+            "site": "stackoverflow",
+            "title": "Zulip"
+        }
     },
     "response": {
         "data": {

--- a/zulip_bots/zulip_bots/bots/stack_overflow/stack_overflow.py
+++ b/zulip_bots/zulip_bots/bots/stack_overflow/stack_overflow.py
@@ -45,11 +45,15 @@ class StackOverflowHandler(object):
         if query == '' or query == 'help':
             return help_text
 
-        query_stack_link = ('http://api.stackexchange.com/2.2/search/advanced?'
-                            'order=desc&sort=relevance&site=stackoverflow&title=%s'
-                            % (urllib.parse.quote(query),))
+        query_stack_url = 'http://api.stackexchange.com/2.2/search/advanced'
+        query_stack_params = dict(
+            order='desc',
+            sort='relevance',
+            site='stackoverflow',
+            title=query
+        )
         try:
-            data = requests.get(query_stack_link)
+            data = requests.get(query_stack_url, params=query_stack_params)
 
         except requests.exceptions.RequestException:
             logging.error('broken link')

--- a/zulip_bots/zulip_bots/bots/susi/fixtures/test_reply.json
+++ b/zulip_bots/zulip_bots/bots/susi/fixtures/test_reply.json
@@ -1,6 +1,9 @@
 {
   "request": {
-    "api_url": "https://api.susi.ai/susi/chat.json?q=hi"
+    "api_url": "https://api.susi.ai/susi/chat.json",
+    "params": {
+      "q": "hi"
+    }
   },
   "response": {
       "query": "hi",

--- a/zulip_bots/zulip_bots/bots/susi/susi.py
+++ b/zulip_bots/zulip_bots/bots/susi/susi.py
@@ -1,5 +1,4 @@
 import requests
-import urllib
 from typing import Dict, Any, Tuple, Union
 
 class SusiHandler(object):
@@ -40,8 +39,7 @@ class SusiHandler(object):
         if msg == 'help' or msg == '':
             bot_handler.send_reply(message, self.usage())
             return
-        encoded_msg = urllib.parse.quote_plus(msg.encode('utf8'))
-        reply = requests.get("https://api.susi.ai/susi/chat.json?q=" + encoded_msg)
+        reply = requests.get("https://api.susi.ai/susi/chat.json", params=dict(q=msg))
         try:
             answer = reply.json()['answers'][0]['actions'][0]['expression']
         except Exception:

--- a/zulip_bots/zulip_bots/bots/weather/fixtures/test_city_not_found.json
+++ b/zulip_bots/zulip_bots/bots/weather/fixtures/test_city_not_found.json
@@ -1,6 +1,10 @@
 {
     "request":{
-        "api_url":"http://api.openweathermap.org/data/2.5/weather?q=fghjklasdfgh&APPID=123456"
+        "api_url":"http://api.openweathermap.org/data/2.5/weather",
+        "params": {
+            "q": "fghjklasdfgh",
+            "APPID": "123456"
+        }
     },
     "response":{
         "cod":"404",

--- a/zulip_bots/zulip_bots/bots/weather/fixtures/test_city_with_country.json
+++ b/zulip_bots/zulip_bots/bots/weather/fixtures/test_city_with_country.json
@@ -1,6 +1,10 @@
 {
     "request":{
-        "api_url":"http://api.openweathermap.org/data/2.5/weather?q=New Delhi, India&APPID=123456"
+        "api_url":"http://api.openweathermap.org/data/2.5/weather",
+        "params": {
+            "q": "New Delhi, India",
+            "APPID": "123456"
+        }
     },
     "response":{
         "coord":{

--- a/zulip_bots/zulip_bots/bots/weather/fixtures/test_only_city.json
+++ b/zulip_bots/zulip_bots/bots/weather/fixtures/test_only_city.json
@@ -1,6 +1,10 @@
 {
     "request":{
-        "api_url":"http://api.openweathermap.org/data/2.5/weather?q=New York&APPID=123456"
+        "api_url":"http://api.openweathermap.org/data/2.5/weather",
+        "params": {
+            "q": "New York",
+            "APPID": "123456"
+        }
     },
     "response":{
         "coord":{

--- a/zulip_bots/zulip_bots/bots/weather/fixtures/test_only_country.json
+++ b/zulip_bots/zulip_bots/bots/weather/fixtures/test_only_country.json
@@ -1,6 +1,10 @@
 {
     "request":{
-        "api_url":"http://api.openweathermap.org/data/2.5/weather?q=United Kingdom&APPID=123456"
+        "api_url":"http://api.openweathermap.org/data/2.5/weather",
+        "params": {
+            "q": "United Kingdom",
+            "APPID": "123456"
+        }
     },
     "response":{
         "coord":{

--- a/zulip_bots/zulip_bots/bots/weather/weather.py
+++ b/zulip_bots/zulip_bots/bots/weather/weather.py
@@ -5,6 +5,8 @@ import logging
 
 from typing import Any, Dict
 
+api_url = 'http://api.openweathermap.org/data/2.5/weather'
+
 class WeatherHandler(object):
     def initialize(self, bot_handler: Any) -> None:
         self.api_key = bot_handler.get_config_info('weather')['key']
@@ -12,8 +14,8 @@ class WeatherHandler(object):
         self.check_api_key(bot_handler)
 
     def check_api_key(self, bot_handler: Any) -> None:
-        url = 'http://api.openweathermap.org/data/2.5/weather?q=nyc&APPID=' + self.api_key
-        test_response = requests.get(url)
+        api_params = dict(q='nyc', APPID=self.api_key)
+        test_response = requests.get(api_url, params=api_params)
         try:
             test_response_data = test_response.json()
             if test_response_data['cod'] == 401:
@@ -40,8 +42,8 @@ class WeatherHandler(object):
         if (message['content'] == 'help') or (message['content'] == ''):
             response = help_content
         else:
-            url = 'http://api.openweathermap.org/data/2.5/weather?q=' + message['content'] + '&APPID='
-            r = requests.get(url + self.api_key)
+            api_params = dict(q=message['content'], APPID=self.api_key)
+            r = requests.get(api_url, params=api_params)
             if r.json()['cod'] == "404":
                 response = "Sorry, city not found"
             else:

--- a/zulip_bots/zulip_bots/bots/wikipedia/fixtures/test_hash_query.json
+++ b/zulip_bots/zulip_bots/bots/wikipedia/fixtures/test_hash_query.json
@@ -1,6 +1,12 @@
 {
     "request": {
-        "api_url":"https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=%23&format=json"
+        "api_url":"https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "list": "search",
+            "srsearch": "#",
+            "format": "json"
+        }
     },
     "response": {
         "data": {

--- a/zulip_bots/zulip_bots/bots/wikipedia/fixtures/test_incorrect_query.json
+++ b/zulip_bots/zulip_bots/bots/wikipedia/fixtures/test_incorrect_query.json
@@ -1,6 +1,12 @@
 {
     "request": {
-        "api_url":"https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=sssssss%20kkkkk&format=json"
+        "api_url":"https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "list": "search",
+            "srsearch": "sssssss kkkkk",
+            "format": "json"
+        }
     },
     "response": {
         "data": {

--- a/zulip_bots/zulip_bots/bots/wikipedia/fixtures/test_multi_word.json
+++ b/zulip_bots/zulip_bots/bots/wikipedia/fixtures/test_multi_word.json
@@ -1,6 +1,12 @@
 {
     "request": {
-        "api_url":"https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=The%20sky%20is%20blue&format=json"
+        "api_url":"https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "list": "search",
+            "srsearch": "The sky is blue",
+            "format": "json"
+        }
     },
     "response": {
         "data": {

--- a/zulip_bots/zulip_bots/bots/wikipedia/fixtures/test_number_query.json
+++ b/zulip_bots/zulip_bots/bots/wikipedia/fixtures/test_number_query.json
@@ -1,6 +1,12 @@
 {
     "request": {
-        "api_url":"https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=123&format=json"
+        "api_url":"https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "list": "search",
+            "srsearch": "123",
+            "format": "json"
+        }
     },
     "response": {
         "data": {

--- a/zulip_bots/zulip_bots/bots/wikipedia/fixtures/test_single_word.json
+++ b/zulip_bots/zulip_bots/bots/wikipedia/fixtures/test_single_word.json
@@ -1,6 +1,12 @@
 {
     "request": {
-        "api_url":"https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=happy&format=json"
+        "api_url":"https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "list": "search",
+            "srsearch": "happy",
+            "format": "json"
+        }
     },
     "response": {
         "data": {

--- a/zulip_bots/zulip_bots/bots/wikipedia/fixtures/test_status_code.json
+++ b/zulip_bots/zulip_bots/bots/wikipedia/fixtures/test_status_code.json
@@ -1,7 +1,13 @@
 
 {
     "request": {
-        "api_url":"https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=Zulip&format=json"
+        "api_url":"https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "list": "search",
+            "srsearch": "Zulip",
+            "format": "json"
+        }
     },
     "response": {
         "data": {

--- a/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
+++ b/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
@@ -47,11 +47,15 @@ class WikipediaHandler(object):
         if query == '':
             return help_text
 
-        query_wiki_link = ('https://en.wikipedia.org/w/api.php?action=query&'
-                           'list=search&srsearch=%s&format=json'
-                           % (urllib.parse.quote(query),))
+        query_wiki_url = 'https://en.wikipedia.org/w/api.php'
+        query_wiki_params = dict(
+            action='query',
+            list='search',
+            srsearch=query,
+            format='json'
+        )
         try:
-            data = requests.get(query_wiki_link)
+            data = requests.get(query_wiki_url, params=query_wiki_params)
 
         except requests.exceptions.RequestException:
             logging.error('broken link')

--- a/zulip_bots/zulip_bots/bots/yoda/fixtures/test_1.json
+++ b/zulip_bots/zulip_bots/bots/yoda/fixtures/test_1.json
@@ -1,6 +1,9 @@
 {
   "request": {
-    "api_url": "https://yoda.p.mashape.com/yoda?sentence=You+will+learn+how+to+speak+like+me+someday.",
+    "api_url": "https://yoda.p.mashape.com/yoda",
+    "params": {
+      "sentence": "You+will+learn+how+to+speak+like+me+someday."
+    },
     "headers": {
       "X-Mashape-Key": "12345678",
       "Accept": "text/plain"

--- a/zulip_bots/zulip_bots/bots/yoda/fixtures/test_2.json
+++ b/zulip_bots/zulip_bots/bots/yoda/fixtures/test_2.json
@@ -1,6 +1,9 @@
 {
   "request": {
-    "api_url": "https://yoda.p.mashape.com/yoda?sentence=you+still+have+much+to+learn",
+    "api_url": "https://yoda.p.mashape.com/yoda",
+    "params": {
+      "sentence": "you+still+have+much+to+learn"
+    },
     "headers": {
       "X-Mashape-Key": "12345678",
       "Accept": "text/plain"

--- a/zulip_bots/zulip_bots/bots/yoda/fixtures/test_api_key_error.json
+++ b/zulip_bots/zulip_bots/bots/yoda/fixtures/test_api_key_error.json
@@ -1,6 +1,9 @@
 {
   "request": {
-    "api_url": "https://yoda.p.mashape.com/yoda?sentence=You+will+learn+how+to+speak+like+me+someday.",
+    "api_url": "https://yoda.p.mashape.com/yoda",
+    "params": {
+      "sentence": "You+will+learn+how+to+speak+like+me+someday."
+    },
     "headers": {
       "X-Mashape-Key": "12345678",
       "Accept": "text/plain"

--- a/zulip_bots/zulip_bots/bots/yoda/fixtures/test_invalid_input.json
+++ b/zulip_bots/zulip_bots/bots/yoda/fixtures/test_invalid_input.json
@@ -1,6 +1,9 @@
 {
   "request": {
-    "api_url": "https://yoda.p.mashape.com/yoda?sentence=@#$%^&*",
+    "api_url": "https://yoda.p.mashape.com/yoda",
+    "params": {
+      "sentence": "@#$%^&*"
+    },
     "headers": {
       "X-Mashape-Key": "12345678",
       "Accept": "text/plain"

--- a/zulip_bots/zulip_bots/bots/yoda/fixtures/test_only_numbers.json
+++ b/zulip_bots/zulip_bots/bots/yoda/fixtures/test_only_numbers.json
@@ -1,6 +1,9 @@
 {
   "request": {
-    "api_url": "https://yoda.p.mashape.com/yoda?sentence=23456",
+    "api_url": "https://yoda.p.mashape.com/yoda",
+    "params": {
+      "sentence": "23456"
+    },
     "headers": {
       "X-Mashape-Key": "12345678",
       "Accept": "text/plain"

--- a/zulip_bots/zulip_bots/bots/yoda/fixtures/test_service_unavailable_error.json
+++ b/zulip_bots/zulip_bots/bots/yoda/fixtures/test_service_unavailable_error.json
@@ -1,6 +1,9 @@
 {
   "request": {
-    "api_url": "https://yoda.p.mashape.com/yoda?sentence=You+will+learn+how+to+speak+like+me+someday.",
+    "api_url": "https://yoda.p.mashape.com/yoda",
+    "params": {
+      "sentence": "You+will+learn+how+to+speak+like+me+someday."
+    },
     "headers": {
       "X-Mashape-Key": "12345678",
       "Accept": "text/plain"

--- a/zulip_bots/zulip_bots/bots/yoda/fixtures/test_unknown_error.json
+++ b/zulip_bots/zulip_bots/bots/yoda/fixtures/test_unknown_error.json
@@ -1,6 +1,9 @@
 {
   "request": {
-    "api_url": "https://yoda.p.mashape.com/yoda?sentence=You+will+learn+how+to+speak+like+me+someday.",
+    "api_url": "https://yoda.p.mashape.com/yoda",
+    "params": {
+      "sentence": "You+will+learn+how+to+speak+like+me+someday."
+    },
     "headers": {
       "X-Mashape-Key": "12345678",
       "Accept": "text/plain"

--- a/zulip_bots/zulip_bots/bots/yoda/yoda.py
+++ b/zulip_bots/zulip_bots/bots/yoda/yoda.py
@@ -55,7 +55,8 @@ class YodaSpeakHandler(object):
 
     def send_to_yoda_api(self, sentence: str) -> str:
         # function for sending sentence to api
-        response = requests.get("https://yoda.p.mashape.com/yoda?sentence=" + sentence,
+        response = requests.get("https://yoda.p.mashape.com/yoda",
+                                params=dict(sentence=sentence),
                                 headers={
                                     "X-Mashape-Key": self.api_key,
                                     "Accept": "text/plain"


### PR DESCRIPTION
Fixes #6.

The PR turned out rather big but all changes are very simple.

### How to encode
I made some research and it turned out that `requests` module already encodes query parameters correctly when query parameters are passed as dictionary `params` parameter in `requests.get|post|...` methods (the result of encoding path parts is same as `urllib.parse.quote` and the result of encoding query parameters is same as `urllib.parse.quote_plus`). 
So, when you call:
```python
requests.get('http://server.domain/api/foo?query=some#query')
```
then actual target of outgoing request will be: `http://server.domain/api/foo?query=some` (the fragment parts was truncated)
But when you call:
```python
requests.get('http://server.domain/api/foo', params=dict(query='some#query'))
```
then actual target of outgoing request will be: `http://server.domain/api/foo?query=some%23query` (this is what we want).
That's why bug in `wikipedia` bot could be avoided if query parameters were passed as `params` parameter in `requests.get()` method.

Also the following should be noted: if there is URL with format 'http://server.com/{part_id}/api' and `part_id` contains _sequence of characters_ matched with some encoded non-safe character e.g. `abc%25def` (very unusual case and, fortunately, our bots have not such problem) then `request` will not encode `%` repeatedly in this `part_id`, so we should manually encode it with `urllib.parse.quote` to make call to `http://server.com/abc%2525def/api`. Also if valid `part_id` contains character like `#` we also should manually encode it with `urllib.parse.quote` too (or part after `#` will be considered as fragment and will be truncated).

### Refactoring Strategy
I found all bots that use the `requests` module and change them with following rules:
- all query parameters should be passed as `params` parameter in `requests.get|post|...` methods;
- all path parts with possible non-safe characters should be encoded with `urllib.parse.quote` method. 
 
### Summary
There is summary reports with description why some changes were or were not made:

#### baremetrics bot
  - not use `urllib.parse.quote` for encoding `source_id` because it consists of `[a-zA-Z0-9]`

#### beeminder bot
  - not use `urllib.parse.quote` for encoding `username` and `goalname` appeared in URL path parts
    because username consists of only letters and number and goalname consists of `[a-z0-9-]`

#### define bot
  - was already updated in https://github.com/zulip/python-zulip-api/pull/125 (only ascii character are allowable)
  - note: currently `owlbot.info` supports only English dictionary but it can be expand (as noted in [README.md](https://github.com/payamnj/owlbot))

#### flock bot
  - all query params were already passed as `params` parameter to `requests.get()` (nothing was changed)

#### front bot
  - not use `urllib.parse.quote` for encoding URL path parts because `conversation_id` does not contain non-safe characters

#### giphy bot
  - all query params were already passed as `params` parameter to `requests.get()` (nothing was changed)

#### github_detail bot
  - not use `urllib.parse.quote` for encoding path parts because `owner`, `repo` contains only alphanumeric with hyphens and issue's `id` is numeric value

#### google_search bot
  - all query params were already passed as `params` parameter to `requests.get()` (nothing was changed)

#### google_translate bot
  - all query params were already passed as `params` parameter to `requests.get()` (nothing was changed)

#### idonethis bot
  - query params should not be encoded (because only `team_id` does not contain non-safe character) but I decide to pass query params as `params` to requests as a canonical way to pass parameter

#### jira bot
  - not use `urllib.parse.quote` for encoding path parts 

#### link_shortener bot
  - all query params were already passed as `params` parameter to `requests.get()` (nothing was changed)

#### mention bot
  - not use `urllib.parse.quote` for encoding path parts (only IDs are used)

#### monkeytestit bot (internal `extract` module)
  - all query params were already passed as `params` parameter to `requests.get()` (nothing was changed)

#### stack_overflow bot
  - use `params` parameter in `requests.get()` method for passing query parameters

#### susi bot
  - use `params` parameter in `requests.get()` method for passing query parameters

#### trello bot
  - not use `urllib.parse.quote` for encoding path parts (only IDs are used)
  - all query params were already passed as `params` parameter to `requests.get()` (nothing was changed)

#### weather bot
  - use `params` parameter in `requests.get()` method for passing query parameters

#### wikipedia bot
  - use `params` parameter in `requests.get()` method for passing query parameters

#### xkcd bot
  - not use `urllib.parse.quote` for encoding path parts (only IDs are used)

#### yoda bot
  - use `params` parameter in `requests.get()` method for passing query parameters

#### youtube bot
  - all query params were already passed as `params` parameter to `requests.get()` (nothing was changed)
