### PR TITLE
api: Allow disabling TLS verification via env vars.

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -392,6 +392,9 @@ class Client(object):
         self.client_name = client
 
         if insecure:
+            logger.warning('Insecure mode enabled. The server\'s SSL/TLS '
+                           'certificate will not be validated, making the '
+                           'HTTPS connection potentially insecure')
             self.tls_verification = False  # type: Union[bool, str]
         elif cert_bundle is not None:
             if not os.path.isfile(cert_bundle):


### PR DESCRIPTION
The `insecure` option was only configurable through a zuliprc file, while the rest of the settings can be specific via both zuliprc and environment variables. Now `insecure` can also be set with the `ZULIP_ALLOW_INSECURE` environment var.

**Testing plan:**

```bash
$ ./tools/test-zulip
test_config_path_with_tilde (tests.test_default_arguments.TestDefaultArguments) ... ok
test_invalid_arguments (tests.test_default_arguments.TestDefaultArguments) ... ok

----------------------------------------------------------------------
Ran 2 tests in 0.003s

OK
$ ./tools/lint
$ cd zulip
$ ZULIP_ALLOW_INSECURE=true python
Python 3.6.3 (default, Oct  3 2017, 21:45:48) 
[GCC 7.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from zulip import Client
>>> c = Client(api_key='123', email='foo@bar.com', site='localhost')
Insecure mode enabled. The server's SSL/TLS certificate will not be validated, making the HTTPS connection potentially insecure
>>> c.tls_verification
False
>>> 
$ ZULIP_ALLOW_INSECURE=false python
Python 3.6.3 (default, Oct  3 2017, 21:45:48) 
[GCC 7.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from zulip import Client
>>> c = Client(api_key='123', email='foo@bar.com', site='localhost')
Insecure mode enabled. The server's SSL/TLS certificate will not be validated, making the HTTPS connection potentially insecure
>>> c.tls_verification
True
>>> 
$ ZULIP_ALLOW_INSECURE=foo python  
Python 3.6.3 (default, Oct  3 2017, 21:45:48) 
[GCC 7.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from zulip import Client
>>> c = Client(api_key='123', email='foo@bar.com', site='localhost')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/yago/Programming/python-zulip-api/zulip/zulip/__init__.py", line 335, in __init__
    "or 'false'".format(insecure_setting))
zulip.ZulipError: The ZULIP_ALLOW_INSECURE environment variable is set to 'foo', it must be 'true' or 'false'
>>>
```