### PR TITLE
requirements: Add 'security' extra_require for requests.

### DIFF
--- a/zulip/setup.py
+++ b/zulip/setup.py
@@ -53,7 +53,7 @@ package_info = dict(
 )  # type: Dict[str, Any]
 
 setuptools_info = dict(
-    install_requires=['requests>=0.12.1',
+    install_requires=['requests[security]>=0.12.1',
                       'six',
                       'typing>=3.5.2.2',
                       ],


### PR DESCRIPTION
There were some issues running bots due to SSL issues.
Adding the extra_require requests[security] adds 3
additional packages that deal with these issues.