### PR TITLE
api: Set required fields in the examples.

### DIFF
--- a/zulip/zulip/examples/create-user
+++ b/zulip/zulip/examples/create-user
@@ -37,10 +37,10 @@ Specify your Zulip API credentials and server in a ~/.zuliprc file or using the 
 import zulip
 
 parser = zulip.add_default_arguments(argparse.ArgumentParser(usage=usage))
-parser.add_argument('--new-email')
-parser.add_argument('--new-password')
-parser.add_argument('--new-full-name')
-parser.add_argument('--new-short-name')
+parser.add_argument('--new-email', required=True)
+parser.add_argument('--new-password', required=True)
+parser.add_argument('--new-full-name', required=True)
+parser.add_argument('--new-short-name', required=True)
 options = parser.parse_args()
 
 client = zulip.init_from_options(options)

--- a/zulip/zulip/examples/edit-message
+++ b/zulip/zulip/examples/edit-message
@@ -24,9 +24,10 @@
 from __future__ import print_function
 import argparse
 
-usage = """edit-message [options] --message=<msg_id> --subject=<new subject> --content=<new content>
+usage = """edit-message [options] --message-id=<msg_id> --subject=<new subject> --content=<new content>
 
-Edits a message that you sent
+Edits a message that you sent. At least one of --subject or --content must be
+specified.
 
 Example: edit-message --message-id="348135" --subject="my subject" --content="test message"
 
@@ -36,7 +37,7 @@ Specify your Zulip API credentials and server in a ~/.zuliprc file or using the 
 import zulip
 
 parser = zulip.add_default_arguments(argparse.ArgumentParser(usage=usage))
-parser.add_argument('--message-id', type=int)
+parser.add_argument('--message-id', type=int, required=True)
 parser.add_argument('--subject', default="")
 parser.add_argument('--content', default="")
 options = parser.parse_args()

--- a/zulip/zulip/examples/edit-message
+++ b/zulip/zulip/examples/edit-message
@@ -36,7 +36,7 @@ Specify your Zulip API credentials and server in a ~/.zuliprc file or using the 
 import zulip
 
 parser = zulip.add_default_arguments(argparse.ArgumentParser(usage=usage))
-parser.add_argument('--message-id', default="")
+parser.add_argument('--message-id', type=int)
 parser.add_argument('--subject', default="")
 parser.add_argument('--content', default="")
 options = parser.parse_args()

--- a/zulip/zulip/examples/get-presence
+++ b/zulip/zulip/examples/get-presence
@@ -32,7 +32,7 @@ Get presence data for another user.
 import zulip
 
 parser = zulip.add_default_arguments(argparse.ArgumentParser(usage=usage))
-parser.add_argument('--email')
+parser.add_argument('--email', required=True)
 options = parser.parse_args()
 
 client = zulip.init_from_options(options)

--- a/zulip/zulip/examples/recent-messages
+++ b/zulip/zulip/examples/recent-messages
@@ -37,7 +37,7 @@ Specify your Zulip API credentials and server in a ~/.zuliprc file or using the 
 import zulip
 
 parser = zulip.add_default_arguments(argparse.ArgumentParser(usage=usage))
-parser.add_argument('--count', default=100)
+parser.add_argument('--count', default=100, type=int)
 options = parser.parse_args()
 
 client = zulip.init_from_options(options)

--- a/zulip/zulip/examples/send-message
+++ b/zulip/zulip/examples/send-message
@@ -34,18 +34,18 @@ Example: send-message --type=stream commits --subject="my subject" --message="te
 Example: send-message user1@example.com user2@example.com
 """
 parser = zulip.add_default_arguments(argparse.ArgumentParser(usage=usage))
-parser.add_argument('recipients', nargs='*')
-parser.add_argument('--subject', default="test")
-parser.add_argument('--message', default="test message")
+parser.add_argument('recipients', nargs='+')
+parser.add_argument('--subject', default='test')
+parser.add_argument('--message', default='test message')
 parser.add_argument('--type', default='private')
 options = parser.parse_args()
 
 client = zulip.init_from_options(options)
 
 message_data = {
-    "type": options.type,
-    "content": options.message,
-    "subject": options.subject,
-    "to": options.recipients,
+    'type': options.type,
+    'content': options.message,
+    'subject': options.subject,
+    'to': options.recipients,
 }
 print(client.send_message(message_data))

--- a/zulip/zulip/examples/upload-file
+++ b/zulip/zulip/examples/upload-file
@@ -42,7 +42,7 @@ If no --file-path is specified, a placeholder text file will be used instead.
 """
 
 parser = zulip.add_default_arguments(argparse.ArgumentParser(usage=usage))
-parser.add_argument('--file-path')
+parser.add_argument('--file-path', required=True)
 options = parser.parse_args()
 
 client = zulip.init_from_options(options)


### PR DESCRIPTION
Now all the API examples have their corresponding arguments set as required when they have to be present for the example to run.

**Testing plan:** Lint checks passed.