### PR TITLE
[WIP] New dependency-alerter bot & support for async bot-handlers

### DIFF
--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -95,6 +95,7 @@ force_include = [
     "zulip_bots/zulip_bots/bots/susi/test_susi.py",
     "zulip_bots/zulip_bots/bots/front/front.py",
     "zulip_bots/zulip_bots/bots/front/test_front.py",
+    "zulip_bots/zulip_bots/bots/dependency_alerter/dependency_alerter.py",
     "tools/deploy"
 ]
 

--- a/zulip_bots/zulip_bots/bots/dependency_alerter/dependency_alerter.py
+++ b/zulip_bots/zulip_bots/bots/dependency_alerter/dependency_alerter.py
@@ -1,0 +1,133 @@
+import requests
+import os
+from datetime import datetime
+
+from typing import Any, Dict, List, Tuple
+
+# See doc.md for instructions on running this code.
+
+class DependencyAlerterHandler:
+    '''
+    This Bot reads a specified file for a list of python project dependencies,
+    and semi-regularly polls PyPI to check if a newer version exists.
+    '''
+
+    META = {
+        'name': 'Dependency-alerter',
+        'description': 'Alerts when newer versions of specified python packages are available.',
+    }
+
+    def usage(self) -> str:
+        return ''' '''
+
+    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+        # Specify named repositories/urls where the requirements.txt files exist in 'repos'
+        repos = {'x': 'http://foo', 'y': 'http://example.com', 'z': 'http://github.com/zulip/ginger'}
+        server_url = 'https://github.com/zulip/zulip/raw/master/requirements/{}.txt'
+        for server_req in ('dev', 'docs', 'mypy', 'pip', 'prod', 'thumbor'):
+            repos['server-'+server_req] = server_url.format(server_req)
+
+        help_title = ("Mention this bot with one of the following to list the "
+                      "current and available dependencies for the following repos/branches:\n")
+        help_text = (help_title +
+                     "\n".join("**{}**: {}".format(name, repos[name]) for name in sorted(repos)))
+
+        content = message['content'].lower()
+
+        if content == '' or content == 'help':
+            bot_handler.send_reply(message, help_text)
+            return
+
+        if content not in repos:
+            not_found_text = "The named repo, **{}**, is not known.\n\n".format(content) + help_text
+            bot_handler.send_reply(message, not_found_text)
+            return
+
+        repo = "**{}**".format(content)
+
+        try:
+            text = download_requirements_txt(repos[content])
+        except DownloadException as e:
+            bot_handler.send_reply(message, str(e).format(repo))
+            return
+
+        packages = minimal_current_package_versions(text)
+        package_versions = collect_current_versions(packages)
+
+        if len(package_versions) == 0:
+            bot_handler.send_reply(message, "No packages at URL for {}.".format(repo))
+            return
+
+        out_of_date_packages = {package: (curr, avail)
+                                for package, (curr, avail) in package_versions.items()
+                                if avail and curr != avail}
+
+        if len(out_of_date_packages) == 0:
+            bot_handler.send_reply(message, "All packages up to date for {}.".format(repo))
+            return
+
+        package_width = max(len(package) for package in out_of_date_packages)
+        versions = ["{:{width}} {:>9} / {:9}".format(package, curr, avail, width=package_width)
+                    for package, (curr, avail) in out_of_date_packages.items()]
+        output = (["The following dependencies appear to not be up to date for {}:".format(repo)] +
+                  ["```"] +
+                  [" "*package_width + " {:>9} / available".format("current")] +
+                  sorted(versions))
+        bot_handler.send_reply(message, "\n".join(output))
+
+class DownloadException(Exception):
+    pass
+
+def download_requirements_txt(url: str) -> List[str]:
+    connection_failure = None
+    response = None
+    try:
+        response = requests.get(url)
+    except requests.exceptions.ConnectionError:
+        connection_failure = "Connection error"
+    except requests.exceptions.RequestException:
+        connection_failure = "General connection error"
+
+    if connection_failure is not None or (response is not None and response.status_code != 200):
+        download_failure_text = "Failed to download URL for {}.\n"
+        if connection_failure is not None:
+            download_failure_text += "{}.".format(connection_failure)
+        else:
+            download_failure_text += "Location inaccessible on server."
+        raise DownloadException(download_failure_text)
+
+    assert response is not None
+    return response.iter_lines(decode_unicode=True)
+
+def minimal_current_package_versions(requirements_txt_lines: List[str]) -> Dict[str, str]:
+    package_lines = [line.strip().split("==") for line in requirements_txt_lines
+                     if '==' in line and line != '\n' and line[0] != '#' and ' # via ' not in line]
+    return dict((line[0], line[1]) for line in package_lines if len(line) == 2)
+
+def collect_current_versions(packages: Dict[str, str]) -> Dict[str, Tuple[str, str]]:
+    return {p: (v, latest_version_by_date(p)) for p, v in packages.items()}
+
+def latest_version_by_date(package_name: str) -> str:
+    data = requests.get("https://pypi.org/pypi/{}/json".format(package_name))
+    if data.status_code == 200:
+        version_uploads = [(version, [datetime.strptime(upload['upload_time'], "%Y-%m-%dT%H:%M:%S")
+                                      for upload in data])
+                           for version, data in data.json()['releases'].items()]
+        first_version_uploads = {version: min(uploads) if uploads else datetime.min
+                                 for version, uploads in version_uploads}
+        latest_upload = (datetime.min, "")
+        for version, upload in first_version_uploads.items():
+            if upload > latest_upload[0]:
+                latest_upload = (upload, version)
+        return latest_upload[1]
+    return ""
+
+# This is not currently used
+def available_versions(package_name: str) -> List[str]:
+    data = requests.get("https://pypi.org/pypi/{}/json".format(package_name))
+    if data.status_code == 200:
+        return sorted(data.json()['releases'].keys())
+    return []
+
+
+handler_class = DependencyAlerterHandler

--- a/zulip_bots/zulip_bots/bots/dependency_alerter/dependency_alerter.py
+++ b/zulip_bots/zulip_bots/bots/dependency_alerter/dependency_alerter.py
@@ -1,4 +1,4 @@
-import requests
+from aiohttp import ClientSession, ClientConnectionError, InvalidURL, ClientError
 import os
 from datetime import datetime
 
@@ -45,14 +45,15 @@ class DependencyAlerterHandler:
 
         repo = "**{}**".format(content)
 
-        try:
-            text = await download_requirements_txt(repos[content])
-        except DownloadException as e:
-            bot_handler.send_reply(message, str(e).format(repo))
-            return
+        async with ClientSession() as session:
+            try:
+                text = await download_requirements_txt(repos[content], session)
+            except DownloadException as e:
+                bot_handler.send_reply(message, str(e).format(repo))
+                return
 
-        packages = await minimal_current_package_versions(text)
-        package_versions = await collect_current_versions(packages)
+            packages = await minimal_current_package_versions(text)
+            package_versions = await collect_current_versions(packages, session)
 
         if len(package_versions) == 0:
             bot_handler.send_reply(message, "No packages at URL for {}.".format(repo))
@@ -78,17 +79,19 @@ class DependencyAlerterHandler:
 class DownloadException(Exception):
     pass
 
-async def download_requirements_txt(url: str) -> List[str]:
+async def download_requirements_txt(url: str, session: ClientSession) -> List[str]:
     connection_failure = None
     response = None
     try:
-        response = requests.get(url)
-    except requests.exceptions.ConnectionError:
+        response = await session.get(url)
+    except ClientConnectionError:
         connection_failure = "Connection error"
-    except requests.exceptions.RequestException:
-        connection_failure = "General connection error"
+    except InvalidURL:
+        connection_failure = "Invalid URL"
+    except ClientError:
+        connection_failure = "General client error"
 
-    if connection_failure is not None or (response is not None and response.status_code != 200):
+    if connection_failure is not None or (response is not None and response.status != 200):
         download_failure_text = "Failed to download URL for {}.\n"
         if connection_failure is not None:
             download_failure_text += "{}.".format(connection_failure)
@@ -97,27 +100,29 @@ async def download_requirements_txt(url: str) -> List[str]:
         raise DownloadException(download_failure_text)
 
     assert response is not None
-    return response.iter_lines(decode_unicode=True)
+    return (await response.text()).split("\n")
 
 async def minimal_current_package_versions(requirements_txt_lines: List[str]) -> Dict[str, str]:
     package_lines = [line.strip().split("==") for line in requirements_txt_lines
                      if '==' in line and line != '\n' and line[0] != '#' and ' # via ' not in line]
     return dict((line[0], line[1]) for line in package_lines if len(line) == 2)
 
-async def collect_current_versions(packages: Dict[str, str]) -> Dict[str, Tuple[str, str]]:
+async def collect_current_versions(packages: Dict[str, str], session: ClientSession) -> Dict[str, Tuple[str, str]]:
     # Python 3.6 is required for await/async in list comprehensions, so with 3.5 must use for loop, not:
     # versions = {p: (v, await latest_version_by_date(p, session)) for p, v in packages.items()}
     versions = dict()
     for p, v in packages.items():
-        versions[p] = (v, await latest_version_by_date(p))
+        versions[p] = (v, await latest_version_by_date(p, session))
     return versions
 
-async def latest_version_by_date(package_name: str) -> str:
-    data = requests.get("https://pypi.org/pypi/{}/json".format(package_name))
-    if data.status_code == 200:
+async def latest_version_by_date(package_name: str, session: ClientSession) -> str:
+    data = await session.get("https://pypi.org/pypi/{}/json".format(package_name))
+    if data.status == 200:
+        # Python 3.6 is required for await/async in list comprehension, so hoist the data.json()
+        json = await data.json()
         version_uploads = [(version, [datetime.strptime(upload['upload_time'], "%Y-%m-%dT%H:%M:%S")
                                       for upload in data])
-                           for version, data in data.json()['releases'].items()]
+                           for version, data in json['releases'].items()]
         first_version_uploads = {version: min(uploads) if uploads else datetime.min
                                  for version, uploads in version_uploads}
         latest_upload = (datetime.min, "")
@@ -128,9 +133,9 @@ async def latest_version_by_date(package_name: str) -> str:
     return ""
 
 # This is not currently used
-def available_versions(package_name: str) -> List[str]:
-    data = requests.get("https://pypi.org/pypi/{}/json".format(package_name))
-    if data.status_code == 200:
+async def available_versions(package_name: str, session: ClientSession) -> List[str]:
+    data = await session.get("https://pypi.org/pypi/{}/json".format(package_name))
+    if data.status == 200:
         return sorted(data.json()['releases'].keys())
     return []
 


### PR DESCRIPTION
Motivation:
* Bot: It's challenging to keep up with latest updates of eg. mypy, so a bot seemed a reasonable idea :)
* Async: Grabbing the information via lots of http-requests takes time, as have other bots on occasion, so allowing for an async handler would enable the bots to be more responsive, to one user or between users.

Dependency-alerter bot:
* Looks at a requested URL for a `requirements.txt`-formatted file, then uses PyPI to check whether those dependencies are up to date.
* A dict of sample URLs are listed (zulip server repo!); open to including others as default :) 
* Marked [WIP], since tests and docs are relatively limited so far.

Async support in lib.py:
* Appears to work well :)
* If the bot has an async handler, then it will try and run that instead of the regular one
* The lib runs the async event-loop in a new thread, and runs the bot async message-handler in that loop when a new message is received
* It shuts down the loop and thread upon SIGINT cleanly
* This will require python 3.5+, which I'm not sure if we specify explicitly (3.4 is maybe implied?)
* We could work with pre-3.5, but the syntax is somewhat less clean
* Python 3.6 would make things more concise again, but that may be going too far for now, at least for the lib
* [WIP] since there may be lib tests needing to be added?

Async support in dependency-alert bot:
* Initially retained use of sync `requests`, but with `async def` and `await` as appropriate
* Expansion of dict comprehension to for loop is required currently, assuming we stick with only python 3.5
* Last commit migrates to the async `aiohttp` from `requests`; this is faster due to the async nature

All commits should pass `lint` and `run-mypy`.

This is also WIP since I've not gone through the idea of async support on czo, but hopefully it seems reasonable, at least as a first step :)

Potential future bot developments:
* cache the requirements / pypi downloads on a 1h-1d basis
* allow the repo dict to be amended at run-time (or use storage)
* improve output of the current/available; maybe a table (though this can look a little ugly?)
* if a download isn't cached, post the message as eg. "processing..." and then `update` it later, given it can take a while (then the user gets feedback, and it places it after the user message, in time)

@showell - since async is bot library related
@timabbott - discussed the bot with you on czo