### PR TITLE
zulip-terminal: Add bot's directory to sys.path.

### DIFF
--- a/zulip_bots/zulip_bots/terminal.py
+++ b/zulip_bots/zulip_bots/terminal.py
@@ -37,6 +37,7 @@ def main():
         bot_path = os.path.abspath(os.path.join(current_dir, 'bots', args.bot, args.bot+'.py'))
         bot_name = args.bot
     bot_dir = os.path.dirname(bot_path)
+    sys.path.insert(0, bot_dir)
 
     try:
         lib_module = import_module_from_source(bot_path, bot_name)


### PR DESCRIPTION
This change was added to run.py in the commit 5992050d8276b523e099b76e55266912020342aa.
The same change is done to terminal.py so that the modules in the bot's directory can be imported when testing using `zulip-terminal` command.