### PR TITLE
Matrix: Naming convention changes.

### DIFF
--- a/zulip/integrations/matrix/README.md
+++ b/zulip/integrations/matrix/README.md
@@ -18,13 +18,14 @@ Hence, this can also be used as a IRC <--> Zulip bridge.
 ## Steps to configure the Matrix bridge
 
 ### 1. Zulip endpoint
-1. Create a generic Zulip bot
-2. (don't forget this step!) Make sure the bot is subscribed to the relevant stream
-2. Enter the bot's email and `api_key` into `matrix_bridge_config.py`
-3. Enter the destination subject, realm and site in `matrix_bridge_config.py`
+1. Create a generic Zulip bot preferable with a formal name similar to `irc-bot`.
+2. (Don't forget this step!) Make sure the bot is subscribed to the relevant stream
+3. Enter the bot's email and `api_key` into `matrix_bridge_config.py`
+4. Enter the destination topic, stream and site in `matrix_bridge_config.py`
 
 ### 2. Matrix endpoint
-1. Create a user on [matrix.org](https://matrix.org/)
+1. Create a user on [matrix.org](https://matrix.org/) preferably with a formal name
+similar to `zulip-bot`.
 2. Enter the user's username and password into `matrix_bridge_config.py`
 3. Enter the host and `room_id` into `matrix_bridge_config.py`
 

--- a/zulip/integrations/matrix/matrix_bridge.py
+++ b/zulip/integrations/matrix/matrix_bridge.py
@@ -70,7 +70,7 @@ def matrix_to_zulip(zulip_client: zulip.Client, zulip_config: Dict[str, Any],
                     "sender": zulip_client.email,
                     "type": "stream",
                     "to": zulip_config["stream"],
-                    "subject": zulip_config["subject"],
+                    "subject": zulip_config["topic"],
                     "content": content,
                 })
             except MatrixRequestError as e:
@@ -137,7 +137,7 @@ def zulip_to_matrix(config: Dict[str, Any], room: Any) -> Callable[[Dict[str, An
 def check_zulip_message_validity(msg: Dict[str, Any], config: Dict[str, Any]) -> bool:
     is_a_stream = msg["type"] == "stream"
     in_the_specified_stream = msg["display_recipient"] == config["stream"]
-    at_the_specified_subject = msg["subject"] == config["subject"]
+    at_the_specified_subject = msg["subject"] == config["topic"]
 
     # We do this to identify the messages generated from Matrix -> Zulip
     # and we make sure we don't forward it again to the Matrix.

--- a/zulip/integrations/matrix/matrix_bridge_config.py
+++ b/zulip/integrations/matrix/matrix_bridge_config.py
@@ -10,6 +10,6 @@ config = {
         "api_key": "aPiKeY",
         "site": "https://chat.zulip.org",
         "stream": "test here",
-        "subject": "matrix"
+        "topic": "matrix"
     }
 }


### PR DESCRIPTION
@timabbott @neiljp How is this for a naming convention? I have manually editted the username for a few networks mentioned here: https://github.com/matrix-org/matrix-appservice-irc/wiki/Bridged-IRC-networks. 
I'll be adding the matrix integration document where I will stress upon the naming convention of the matrix user.

screenshots:
![screen shot 2018-05-21 at 9 30 40 pm](https://user-images.githubusercontent.com/25330892/40317154-39acc2ae-5d3e-11e8-9987-015c0480250b.png)
![screen shot 2018-05-21 at 9 30 31 pm](https://user-images.githubusercontent.com/25330892/40317156-3c9267a8-5d3e-11e8-8734-bbbb5efa4880.png)

