### PR TITLE
zulip_botserver: Handle all requests from the root / endpoint.

### DIFF
--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -2,6 +2,7 @@ import configparser
 import json
 import logging
 import os
+import re
 import signal
 import sys
 import time
@@ -221,6 +222,15 @@ def extract_query_without_mention(message: Dict[str, Any], client: ExternalBotHa
         return None
     return message['content'][len(mention):].lstrip()
 
+def extract_first_mention(message: Dict[str, Any]) -> str:
+    """
+    Returns the name inside the first @mention in message `message`.
+    Throws an exception if `message` contains no @mention.
+    """
+    mention_regex = re.search(r"\@\*\*(?P<mention>.*?)\*\*", message['content'])
+    if mention_regex is None:
+        raise ValueError("message contains no @mention.")
+    return mention_regex.group("mention")
 
 def is_private_message_from_another_user(message_dict: Dict[str, Any], current_user_id: int) -> bool:
     """

--- a/zulip_botserver/tests/server_test_lib.py
+++ b/zulip_botserver/tests/server_test_lib.py
@@ -17,12 +17,12 @@ class BotServerTestCase(TestCase):
         available_bots: Optional[List[str]]=None,
         bots_config: Optional[Dict[str, Dict[str, str]]]=None,
         bot_handlers: Optional[Dict[str, Any]]=None,
-        payload_url: str="/bots/helloworld",
-        message: Optional[Dict[str, Any]]=dict(message={'key': "test message"}),
+        message: Optional[Dict[str, Any]]=dict(message={'content': "@**foo bot** bar"}),
         check_success: bool=False,
         third_party_bot_conf: Optional[configparser.ConfigParser]=None,
     ) -> None:
         if available_bots is not None and bots_config is not None:
+            server.bots_config = bots_config
             bots_lib_modules = server.load_lib_modules(available_bots)
             server.app.config["BOTS_LIB_MODULES"] = bots_lib_modules
             if bot_handlers is None:
@@ -31,7 +31,7 @@ class BotServerTestCase(TestCase):
             server.app.config["BOT_HANDLERS"] = bot_handlers
             server.app.config["MESSAGE_HANDLERS"] = message_handlers
 
-        response = self.app.post(payload_url, data=json.dumps(message))
+        response = self.app.post(data=json.dumps(message))
 
         if check_success:
             assert 200 <= response.status_code < 300

--- a/zulip_botserver/tests/test.conf
+++ b/zulip_botserver/tests/test.conf
@@ -1,8 +1,10 @@
 [helloworld]
+name=helloworldbot
 key=value
 email=helloworld-bot@zulip.com
 site=http://localhost
 [giphy]
+name=foo bar
 key=value2
 email=giphy-bot@zulip.com
 site=http://localhost

--- a/zulip_botserver/tests/test_server.py
+++ b/zulip_botserver/tests/test_server.py
@@ -24,6 +24,7 @@ class BotServerTests(BotServerTestCase):
         available_bots = ['helloworld']
         bots_config = {
             'helloworld': {
+                'name': 'foo bar',
                 'email': 'helloworld-bot@zulip.com',
                 'key': '123456789qwertyuiop',
                 'site': 'http://localhost',
@@ -31,6 +32,7 @@ class BotServerTests(BotServerTestCase):
         }
         self.assert_bot_server_response(available_bots=available_bots,
                                         bots_config=bots_config,
+                                        message=dict(message={'content': "@**foo bar** baz"}),
                                         check_success=True)
 
     @mock.patch('zulip_bots.lib.ExternalBotHandler')
@@ -38,11 +40,13 @@ class BotServerTests(BotServerTestCase):
         available_bots = ['helloworld', 'help']
         bots_config = {
             'helloworld': {
+                'name': 'foo bar',
                 'email': 'helloworld-bot@zulip.com',
                 'key': '123456789qwertyuiop',
                 'site': 'http://localhost',
             },
             'help': {
+                'name': 'foo bar',
                 'email': 'help-bot@zulip.com',
                 'key': '123456789qwertyuiop',
                 'site': 'http://localhost',
@@ -50,11 +54,12 @@ class BotServerTests(BotServerTestCase):
         }
         self.assert_bot_server_response(available_bots=available_bots,
                                         bots_config=bots_config,
+                                        message=dict(message={'content': "@**foo bar** baz"}),
                                         check_success=True)
 
     def test_bot_module_not_exists(self) -> None:
         self.assert_bot_server_response(available_bots=[],
-                                        payload_url="/bots/not_supported_bot",
+                                        message=dict(message={'content': "@**foo bar** baz"}),
                                         check_success=False)
 
     @mock.patch('logging.error')
@@ -63,6 +68,7 @@ class BotServerTests(BotServerTestCase):
         available_bots = ['nonexistent-bot']
         bots_config = {
             'nonexistent-bot': {
+                'name': 'foo bar',
                 'email': 'helloworld-bot@zulip.com',
                 'key': '123456789qwertyuiop',
                 'site': 'http://localhost',
@@ -93,11 +99,13 @@ class BotServerTests(BotServerTestCase):
         bot_conf1 = server.read_config_file(os.path.join(current_dir, "test.conf"))
         expected_config1 = {
             'helloworld': {
+                'name': 'helloworldbot',
                 'email': 'helloworld-bot@zulip.com',
                 'key': 'value',
                 'site': 'http://localhost',
             },
             'giphy': {
+                'name': 'foo bar',
                 'email': 'giphy-bot@zulip.com',
                 'key': 'value2',
                 'site': 'http://localhost',
@@ -107,6 +115,7 @@ class BotServerTests(BotServerTestCase):
         bot_conf2 = server.read_config_file(os.path.join(current_dir, "test.conf"), "redefined_bot")
         expected_config2 = {
             'redefined_bot': {
+                'name': 'helloworldbot',
                 'email': 'helloworld-bot@zulip.com',
                 'key': 'value',
                 'site': 'http://localhost',


### PR DESCRIPTION
Previously, the Botserver determined which bot to run by
dispatching on a different URL endpoint /bots/<botname> for each bot.
Now, instead, the Botserver determines which bot to run by the section
header of the bot in the flaskbotrc.
This implementation simplifies the setup of the Botserver. However,
without the dispatch on the URL endpoint, the Botserver cannot tell
anymore which bot to run for an incoming message. Therefore, it now
inspects each message for the bot name that is @mentioned in it. It
then looks for a section in the flaskbotrc that has this name as a
property and runs the associated bot. The name property is newly
introduced with this commit.

This depends on https://github.com/zulip/zulip/pull/9493.