### PR TITLE
[WIP] Add async option for bots 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ twine
 coverage>=4.4.1
 pycodestyle==2.3.1
 mock
+asynctest
 -e ./zulip
 -e ./zulip_bots
 -e ./zulip_botserver

--- a/tools/.coveragerc
+++ b/tools/.coveragerc
@@ -23,3 +23,5 @@ omit =
     tools/test-bots
     tools/test-botserver
     tools/test-zulip
+    # Contains async keywords, which python 3.4 doesn't support
+    zulip_bots/zulip_bots/lib_tests.py

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -9,7 +9,7 @@ import time
 import asyncio
 from threading import Thread
 
-from typing import Any, Optional, List, Dict, IO, Text, Awaitable
+from typing import Any, Optional, List, Dict, IO, Text  # XXX: When python 3.5, add Awaitable
 
 from zulip import Client, ZulipError
 from zulip_bots.custom_exceptions import ConfigValidationError
@@ -43,7 +43,7 @@ class AsyncThread(Thread):
             self._loop.call_soon_threadsafe(self._loop.stop)
         self.join()
 
-    def run_coroutine(self, coroutine: Awaitable[Any]) -> None:
+    def run_coroutine(self, coroutine: Any) -> None:  # XXX When python 3.5, Awaitable[Any]
         if self._loop is None:
             raise RuntimeError("No event loop available.")
         asyncio.run_coroutine_threadsafe(coroutine, self._loop)

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -42,6 +42,8 @@ class AsyncThread(Thread):
 
     def stop_and_join(self) -> None:
         if self._loop is not None:
+            while asyncio.Task.all_tasks():  # XXX Busy-wait until tasks complete
+                pass
             self._loop.call_soon_threadsafe(self._loop.stop)
         self.join()
 

--- a/zulip_bots/zulip_bots/lib_tests.py
+++ b/zulip_bots/zulip_bots/lib_tests.py
@@ -240,6 +240,9 @@ class LibTest(TestCase):
                 ######## Also we test that the non-async function was not called
                 mock_bot_handler.handle_message.assert_not_called()
 
+                import asyncio
+                asyncio.sleep(3)
+
                 shut_down_message_handler_for_bot()
 
             fake_client.call_on_each_event = call_on_each_event_mock.__get__(

--- a/zulip_bots/zulip_bots/lib_tests.py
+++ b/zulip_bots/zulip_bots/lib_tests.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, patch, ANY, create_autospec
+# Import these from asynctest rather than unittest.mock, to handle coroutines
+from asynctest import MagicMock, patch, create_autospec, ANY
+
 from zulip_bots.lib import (
     ExternalBotHandler,
     StateHandler,
@@ -34,12 +36,32 @@ class FakeClient:
     def send_message(self, message):
         pass
 
+class FakeBrokenBotHandler:
+    def usage(self):
+        return '''
+            This is a fake bot handler that is used
+            to spec BotHandler mocks with absent handler.
+            '''
+
 class FakeBotHandler:
     def usage(self):
         return '''
             This is a fake bot handler that is used
             to spec BotHandler mocks.
             '''
+
+    def handle_message(self, message, bot_handler):
+        pass
+
+class FakeAsyncBotHandler:
+    def usage(self):
+        return '''
+            This is a fake bot handler that is used
+            to spec async-capable BotHandler mocks.
+            '''
+
+    async def handle_message_async(self, message, bot_handler):
+        pass
 
     def handle_message(self, message, bot_handler):
         pass
@@ -132,6 +154,25 @@ class LibTest(TestCase):
         )
         to = {'email': 'Some@User'}
 
+    def test_detect_absence_of_message_handler_in_bot(self):
+        with patch('zulip_bots.lib.Client', new=FakeClient) as fake_client:
+            mock_lib_module = MagicMock()
+            # __file__ is not mocked by MagicMock(), so we assign a mock value manually.
+            mock_lib_module.__file__ = "foo"
+            ##### NOTE *FakeBrokenBotHandler*
+            mock_bot_handler = create_autospec(FakeBrokenBotHandler)
+            mock_lib_module.handler_class.return_value = mock_bot_handler
+
+            from io import StringIO
+            with self.assertRaises(SystemExit):
+                with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+                    run_message_handler_for_bot(lib_module=mock_lib_module,
+                                                quiet=True,
+                                                config_file=None,
+                                                bot_config_file=None,
+                                                bot_name='testbot')
+#                    mock_stdout.assert_called_with('')
+
     def test_run_message_handler_for_bot(self):
         with patch('zulip_bots.lib.Client', new=FakeClient) as fake_client:
             mock_lib_module = MagicMock()
@@ -158,6 +199,45 @@ class LibTest(TestCase):
                 mock_bot_handler.handle_message.assert_called_with(
                     message=expected_message,
                     bot_handler=ANY)
+
+            fake_client.call_on_each_event = call_on_each_event_mock.__get__(
+                fake_client, fake_client.__class__)
+            run_message_handler_for_bot(lib_module=mock_lib_module,
+                                        quiet=True,
+                                        config_file=None,
+                                        bot_config_file=None,
+                                        bot_name='testbot')
+
+    def test_run_message_handler_async_for_async_capable_bot(self):
+        with patch('zulip_bots.lib.Client', new=FakeClient) as fake_client:
+            mock_lib_module = MagicMock()
+            # __file__ is not mocked by MagicMock(), so we assign a mock value manually.
+            mock_lib_module.__file__ = "foo"
+            ###### NOTE the different BotHandler, with handle_message_async
+            mock_bot_handler = create_autospec(FakeAsyncBotHandler)
+            mock_lib_module.handler_class.return_value = mock_bot_handler
+
+            def call_on_each_event_mock(self, callback, event_types=None, narrow=None):
+                def test_message(message, flags):
+                    event = {'message': message,
+                             'flags': flags,
+                             'type': 'message'}
+                    callback(event)
+
+                # In the following test, expected_message is the dict that we expect
+                # to be passed to the bot's handle_message function.
+                original_message = {'content': '@**Alice** bar',
+                                    'type': 'stream'}
+                expected_message = {'type': 'stream',
+                                    'content': 'bar',
+                                    'full_content': '@**Alice** bar'}
+                test_message(original_message, {'mentioned'})
+                ######## Here we test for the async function instead
+                mock_bot_handler.handle_message_async.assert_called_with(
+                    message=expected_message,
+                    bot_handler=ANY)
+                ######## Also we test that the non-async function was not called
+                mock_bot_handler.handle_message.assert_not_called()
 
             fake_client.call_on_each_event = call_on_each_event_mock.__get__(
                 fake_client, fake_client.__class__)

--- a/zulip_bots/zulip_bots/lib_tests.py
+++ b/zulip_bots/zulip_bots/lib_tests.py
@@ -6,6 +6,7 @@ from zulip_bots.lib import (
     ExternalBotHandler,
     StateHandler,
     run_message_handler_for_bot,
+    shut_down_message_handler_for_bot,
 )
 
 class FakeClient:
@@ -238,6 +239,8 @@ class LibTest(TestCase):
                     bot_handler=ANY)
                 ######## Also we test that the non-async function was not called
                 mock_bot_handler.handle_message.assert_not_called()
+
+                shut_down_message_handler_for_bot()
 
             fake_client.call_on_each_event = call_on_each_event_mock.__get__(
                 fake_client, fake_client.__class__)


### PR DESCRIPTION
This breaks the `async` support out of #390, aiming to add compatibility with python 3.4 and tests.

This is currently WIP since:
* some commits could be squashed together, notably the first 3 together
* tests currently break on coverage, since the last commit doesn't appear to remove `lib_tests.py` from the coverage (which otherwise breaks for python 3.4 when examining the test code)
* the tests might be able to be refactored, and the comments standardised ;)

Tests can finish smoothly with the new `shut_down_message_handler_for_bot`, but I just noticed they (locally) generate the following, which they did not before:
```
ERROR:asyncio:Task was destroyed but it is pending!
task: <Task pending coro=<CoroutineMock._mock_call.<locals>.proxy() running at /home/neil/repos/python-zulip-api/zulip-api-py3-venv/lib/python3.5/site-packages/asynctest/mock.py:545> cb=[_chain_future.<locals>._call_set_state() at /usr/lib/python3.5/asyncio/futures.py:459]>
```
This is resolved through the last commit, including modifying the test so it more reliably triggers it (though the reason for this isn't completely clear).