### PR TITLE
Ensure additional bot testing & general test-bots improvements

### DIFF
--- a/zulip_bots/zulip_bots/bots/merels/test/test_constants.py
+++ b/zulip_bots/zulip_bots/bots/merels/test/test_constants.py
@@ -1,6 +1,6 @@
 import unittest
 
-from libraries import constants
+from ..libraries import constants
 
 
 class CheckIntegrity(unittest.TestCase):

--- a/zulip_bots/zulip_bots/bots/merels/test/test_database.py
+++ b/zulip_bots/zulip_bots/bots/merels/test/test_database.py
@@ -1,7 +1,7 @@
 import unittest
 
-from libraries import database
-from libraries import game_data
+from ..libraries import database
+from ..libraries import game_data
 from zulip_bots.simple_lib import SimpleStorage
 
 

--- a/zulip_bots/zulip_bots/bots/merels/test/test_game.py
+++ b/zulip_bots/zulip_bots/bots/merels/test/test_game.py
@@ -1,7 +1,7 @@
 import unittest
 
-from libraries import game
-from libraries import database
+from ..libraries import game
+from ..libraries import database
 
 from zulip_bots.simple_lib import SimpleStorage
 

--- a/zulip_bots/zulip_bots/bots/merels/test/test_interface.py
+++ b/zulip_bots/zulip_bots/bots/merels/test/test_interface.py
@@ -1,6 +1,6 @@
 import unittest
 
-from libraries import interface
+from ..libraries import interface
 
 
 class BoardLayoutTest(unittest.TestCase):

--- a/zulip_bots/zulip_bots/bots/merels/test/test_mechanics.py
+++ b/zulip_bots/zulip_bots/bots/merels/test/test_mechanics.py
@@ -1,9 +1,9 @@
 import unittest
 
-from libraries import database
-from libraries import game_data
-from libraries import interface
-from libraries import mechanics
+from ..libraries import database
+from ..libraries import game_data
+from ..libraries import interface
+from ..libraries import mechanics
 from zulip_bots.simple_lib import SimpleStorage
 
 


### PR DESCRIPTION
See #402 for reference, but:
* Consistently name gameoffifteen as game_of_fifteen (based on existing bot testing requirements)
* Enable testing of 3 bots by simply adding `__init__.py` files
* Slightly modify 3 bots (twitpost, witai, chess) and add `__init__.py` to get them testing
* Incrementally improve test discovery and style in `test-bots`

This should be easy to review, as most commits are small and many are independent.

The penultimate commit enables the updated `test-bots` to run cleanly for bots with no `__init__.py`, as currently (mistakenly!). This behavior can be modified later (and controlled at run-time with `--error-on-no-init`), but maintains current status until the last bot with tests but no `__init__.py` has their tests fully fixed - which the last commit starts to do.

NOTE: From "Use unused available_bots to discover tests" to "Detect absent `__init__.py` & optionally exit", merels will currently fail; this can easily be minimised with a rebase, but to avoid it entirely would require a little more work.