### PR TITLE
#357 Add a better way to run standalone bots 

### DIFF
--- a/zulip_bots/zulip_bots/finder.py
+++ b/zulip_bots/zulip_bots/finder.py
@@ -23,12 +23,22 @@ def import_module_from_source(path: Text, name: Text) -> Any:
 
     return module
 
-def resolve_bot_path(name: Text) -> Tuple[Text, Text]:
+def import_module_by_name(name: Text) -> Any:
+    import importlib
+    try:
+        return importlib.import_module(name)
+    except ModuleNotFoundError:
+        return None
+
+def resolve_bot_path(name: Text) -> Optional[Tuple[Text, Text]]:
     if os.path.isfile(name):
         bot_path = os.path.abspath(name)
         bot_name = splitext(basename(bot_path))[0]
+        return (bot_path, bot_name)
     else:
-        bot_path = os.path.abspath(os.path.join(current_dir, 'bots', name, name + '.py'))
         bot_name = name
+        bot_path = os.path.abspath(os.path.join(current_dir, 'bots', bot_name, bot_name + '.py'))
+        if os.path.isfile(bot_path):
+            return (bot_path, bot_name)
 
-    return (bot_path, bot_name)
+    return None

--- a/zulip_bots/zulip_bots/run.py
+++ b/zulip_bots/zulip_bots/run.py
@@ -81,25 +81,34 @@ def exit_gracefully_if_bot_config_file_does_not_exist(bot_config_file: str) -> N
 def main() -> None:
     args = parse_args()
 
-    bot_path, bot_name = finder.resolve_bot_path(args.bot)
-    sys.path.insert(0, os.path.dirname(bot_path))
+    result = finder.resolve_bot_path(args.bot)
+    if result:
+        bot_path, bot_name = result
+        sys.path.insert(0, os.path.dirname(bot_path))
 
-    if args.provision:
-        provision_bot(os.path.dirname(bot_path), args.force)
+        if args.provision:
+            provision_bot(os.path.dirname(bot_path), args.force)
 
-    try:
-        lib_module = finder.import_module_from_source(bot_path, bot_name)
-    except ImportError as e:
-        req_path = os.path.join(os.path.dirname(bot_path), "requirements.txt")
-        with open(req_path) as fp:
-            deps_list = fp.read()
+        try:
+            lib_module = finder.import_module_from_source(bot_path, bot_name)
+        except ImportError as e:
+            req_path = os.path.join(os.path.dirname(bot_path), "requirements.txt")
+            with open(req_path) as fp:
+                deps_list = fp.read()
 
-        dep_err_msg = ("ERROR: The following dependencies for the {bot_name} bot are not installed:\n\n"
-                       "{deps_list}\n"
-                       "If you'd like us to install these dependencies, run:\n"
-                       "    zulip-run-bot {bot_name} --provision")
-        print(dep_err_msg.format(bot_name=bot_name, deps_list=deps_list))
-        sys.exit(1)
+            dep_err_msg = ("ERROR: The following dependencies for the {bot_name} bot are not installed:\n\n"
+                           "{deps_list}\n"
+                           "If you'd like us to install these dependencies, run:\n"
+                           "    zulip-run-bot {bot_name} --provision")
+            print(dep_err_msg.format(bot_name=bot_name, deps_list=deps_list))
+            sys.exit(1)
+    else:
+        lib_module = finder.import_module_by_name(args.bot)
+        if lib_module:
+            bot_name = lib_module.__name__
+            if args.provision:
+                print("ERROR: Could not load bot's module for '{}'. Exiting now.")
+                sys.exit(1)
 
     if lib_module is None:
         print("ERROR: Could not load bot module. Exiting now.")


### PR DESCRIPTION
Fixes #357.

Change logic to run bot by `zulip-run-bot` to the following:
- If `zulip-run-bot` was run with _name_ as path to bot's file, then import bot from file and add bot's parent dir to `sys.path`;
- If `zulip-run-bot` was run with some _name_ (not pointing to file) then:
  - try to import bot from file located at `zulip_bots/zulip_bots/bots/{name}/{name}.py`. If import was completed succesfully, then add add bot's parent dir (`zulip_bots/zulip_bots/bots/{name}`) to `sys.path`;
  - try to import bot by specified module _name_. If import was completed successfully, then also check that `args.provision` was *not* passed