### PR TITLE
bots: Add tests for trivia_quiz bot.

### DIFF
--- a/zulip_bots/zulip_bots/bots/trivia_quiz/fixtures/test_new_question.json
+++ b/zulip_bots/zulip_bots/bots/trivia_quiz/fixtures/test_new_question.json
@@ -1,0 +1,23 @@
+{
+    "request":{
+        "api_url":"https://opentdb.com/api.php?amount=1&type=multiple"
+    },
+    "response":{
+        "response_code":0,
+        "results":[
+            {
+                "category":"Animals",
+                "type":"multiple",
+                "difficulty":"easy",
+                "question":"Which class of animals are newts members of?",
+                "correct_answer":"Amphibian",
+                "incorrect_answers":["Fish","Reptiles","Mammals"]
+            }
+        ]
+    },
+    "response-headers":{
+        "status":200,
+        "ok":true,
+        "content-type":"application/json; charset=utf-8"
+    }
+}

--- a/zulip_bots/zulip_bots/bots/trivia_quiz/fixtures/test_status_code.json
+++ b/zulip_bots/zulip_bots/bots/trivia_quiz/fixtures/test_status_code.json
@@ -1,0 +1,14 @@
+{
+    "request": {
+        "api_url":"https://opentdb.com/api.php?amount=1&type=multiple"
+    },
+    "response": {
+        "data": {
+            "status_code":404
+        }
+    },
+    "response-headers":{
+        "status":404,
+        "content-type":"text/html"
+    }
+}

--- a/zulip_bots/zulip_bots/bots/trivia_quiz/requirements.txt
+++ b/zulip_bots/zulip_bots/bots/trivia_quiz/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/zulip_bots/zulip_bots/bots/trivia_quiz/test_trivia_quiz.py
+++ b/zulip_bots/zulip_bots/bots/trivia_quiz/test_trivia_quiz.py
@@ -1,0 +1,71 @@
+import json
+
+from unittest.mock import patch
+from typing import Optional
+
+from zulip_bots.test_lib import (
+    BotTestCase,
+    read_bot_fixture_data,
+)
+
+from zulip_bots.bots.trivia_quiz.trivia_quiz import (
+    get_quiz_from_payload,
+)
+
+class TestTriviaQuizBot(BotTestCase):
+    bot_name = "trivia_quiz"  # type: str
+
+    new_question_response = '\nQ: Which class of animals are newts members of?\n\n' + \
+        '* **A** Amphibian\n' + \
+        '* **B** Fish\n' + \
+        '* **C** Reptiles\n' + \
+        '* **D** Mammals\n' + \
+        '**reply**: answer Q001 <letter>'
+
+    def _test(self, message: str, response: str, fixture: Optional[str]=None) -> None:
+        if fixture:
+            with self.mock_http_conversation(fixture):
+                self.verify_reply(message, response)
+        else:
+            self.verify_reply(message, response)
+
+    def test_bot_responds_to_empty_message(self) -> None:
+        self._test('', 'type "new" for a new question')
+
+    def test_bot_new_question(self) -> None:
+        with patch('random.shuffle'):
+            self._test('new', self.new_question_response, 'test_new_question')
+
+    def test_question_not_available(self) -> None:
+        self._test('new', 'Uh-Oh! Trivia service is down.', 'test_status_code')
+
+    def test_invalid_answer(self) -> None:
+        invalid_replies = ['answer A',
+                           'answer A Q10',
+                           'answer Q001 K',
+                           'answer 001 A']
+        for reply in invalid_replies:
+            self._test(reply, 'Invalid answer format')
+
+    def test_invalid_quiz_id(self) -> None:
+        self._test('answer Q100 A', 'Invalid quiz id')
+
+    def test_answers(self) -> None:
+        quiz_payload = read_bot_fixture_data('trivia_quiz', 'test_new_question')['response']
+        with patch('random.shuffle'):
+            quiz = get_quiz_from_payload(quiz_payload)
+
+        self.assertEqual(quiz['question'], 'Which class of animals are newts members of?')
+        self.assertEqual(quiz['correct_letter'], 'A')
+        self.assertEqual(quiz['answers']['D'], 'Mammals')
+
+        # test incorrect answer
+        with patch('zulip_bots.bots.trivia_quiz.trivia_quiz.get_quiz_from_id',
+                   return_value=json.dumps(quiz)):
+            self._test('answer Q001 B', '**WRONG!** B is not correct :disappointed:')
+
+        # test correct answer
+        with patch('zulip_bots.bots.trivia_quiz.trivia_quiz.get_quiz_from_id',
+                   return_value=json.dumps(quiz)):
+            with patch('zulip_bots.bots.trivia_quiz.trivia_quiz.start_new_quiz') as mock_new_quiz:
+                self._test('answer Q001 A', '**CORRECT!** Amphibian :tada:')

--- a/zulip_bots/zulip_bots/bots/trivia_quiz/trivia_quiz.py
+++ b/zulip_bots/zulip_bots/bots/trivia_quiz/trivia_quiz.py
@@ -1,0 +1,208 @@
+import html
+import json
+import requests
+import random
+import re
+from zulip_bots.lib import Any
+
+from typing import Optional, Any, Dict
+
+class NotAvailableException(Exception):
+    pass
+
+class InvalidAnswerException(Exception):
+    pass
+
+class TriviaQuizHandler:
+    def usage(self) -> str:
+        return '''
+            This plugin will give users a trivia question from
+            the open trivia database at opentdb.com.'''
+
+    def handle_message(self, message: Dict[str, Any], bot_handler: Any) -> None:
+        query = message['content']
+        if query == 'new':
+            try:
+                start_new_quiz(message, bot_handler)
+                return
+            except NotAvailableException:
+                bot_response = 'Uh-Oh! Trivia service is down.'
+                bot_handler.send_reply(message, bot_response)
+                return
+        elif query.startswith('answer'):
+            try:
+                (quiz_id, answer) = parse_answer(query)
+            except InvalidAnswerException:
+                bot_response = 'Invalid answer format'
+                bot_handler.send_reply(message, bot_response)
+                return
+            try:
+                quiz_payload = bot_handler.storage.get(quiz_id)
+            except KeyError:
+                bot_response = 'Invalid quiz id'
+                bot_handler.send_reply(message, bot_response)
+                return
+            quiz = json.loads(quiz_payload)
+            correct, bot_response = grade_question(quiz, answer)
+            bot_handler.send_reply(message, bot_response)
+            if correct:
+                start_new_quiz(message, bot_handler)
+            return
+        else:
+            bot_response = 'type "new" for a new question'
+        bot_handler.send_reply(message, bot_response)
+
+def start_new_quiz(message: Dict[str, Any], bot_handler: Any) -> None:
+    quiz = get_trivia_quiz()
+    quiz_id = generate_quiz_id(bot_handler.storage)
+    bot_response = format_quiz_for_markdown(quiz_id, quiz)
+    widget_content = format_quiz_for_widget(quiz_id, quiz)
+    bot_handler.storage.put(quiz_id, json.dumps(quiz))
+    bot_handler.send_reply(message, bot_response, widget_content)
+
+def parse_answer(query):
+    m = re.match('answer\s+(Q...)\s+(.)', query)
+    if not m:
+        raise InvalidAnswerException()
+
+    quiz_id = m.group(1)
+    answer = m.group(2).upper()
+    if answer not in 'ABCD':
+        raise InvalidAnswerException()
+
+    return (quiz_id, answer)
+
+def get_trivia_quiz() -> str:
+    payload = get_trivia_payload()
+    quiz = get_quiz_from_payload(payload)
+    return quiz
+
+def get_trivia_payload() -> str:
+
+    url = 'https://opentdb.com/api.php?amount=1&type=multiple'
+
+    try:
+        data = requests.get(url)
+
+    except requests.exceptions.RequestException:
+        raise NotAvailableException()
+
+    if data.status_code != 200:
+        raise NotAvailableException()
+
+    payload = data.json()
+    return payload
+
+def fix_quotes(s):
+    # opentdb is nice enough to escape HTML for us, but
+    # we are sending this to code that does that already :)
+    #
+    # Meanwhile Python took until version 3.4 to have a
+    # simple html.unescape function.
+    try:
+        return html.unescape(s)
+    except Exception:
+        raise Exception('Please use python3.4 or later for this bot.')
+
+def get_quiz_from_payload(payload):
+    result = payload['results'][0]
+    question = result['question']
+    letters = ['A', 'B', 'C', 'D']
+    random.shuffle(letters)
+    correct_letter = letters[0]
+    answers = dict()
+    answers[correct_letter] = result['correct_answer']
+    for i in range(3):
+        answers[letters[i+1]] = result['incorrect_answers'][i]
+    answers = {
+        letter: fix_quotes(answer)
+        for letter, answer
+        in answers.items()
+    }
+    quiz = dict(
+        question=fix_quotes(question),
+        answers=answers,
+        correct_letter=correct_letter,
+    )
+    return quiz
+
+def generate_quiz_id(storage) -> str:
+    try:
+        quiz_num = storage.get('quiz_id')
+    except KeyError:
+        quiz_num = 0
+    quiz_num += 1
+    quiz_num = quiz_num % (1000)
+    storage.put('quiz_id', quiz_num)
+    quiz_id = 'Q%03d' % (quiz_num,)
+    return quiz_id
+
+def format_quiz_for_widget(quiz_id, quiz):
+    widget_type = 'zform'
+    question = quiz['question']
+    answers = quiz['answers']
+
+    heading = quiz_id + ': ' + question
+
+    def get_choice(letter):
+        answer = answers[letter]
+        reply = 'answer ' + quiz_id + ' ' + letter
+
+        return dict(
+            type='multiple_choice',
+            short_name=letter,
+            long_name=answer,
+            reply=reply,
+        )
+
+    choices = [get_choice(letter) for letter in 'ABCD']
+
+    extra_data = dict(
+        type='choices',
+        heading=heading,
+        choices=choices,
+    )
+
+    widget_content = dict(
+        widget_type=widget_type,
+        extra_data=extra_data,
+    )
+    payload = json.dumps(widget_content)
+    return payload
+
+def format_quiz_for_markdown(quiz_id, quiz):
+    question = quiz['question']
+    answers = quiz['answers']
+    answer_list = '\n'.join([
+        '* **{letter}** {answer}'.format(
+            letter=letter,
+            answer=answers[letter],
+        )
+        for letter in 'ABCD'
+    ])
+    how_to_respond = '''**reply**: answer {quiz_id} <letter>'''.format(quiz_id=quiz_id)
+
+    content = '''
+Q: {question}
+
+{answer_list}
+{how_to_respond}'''.format(
+        question=question,
+        answer_list=answer_list,
+        how_to_respond=how_to_respond,
+    )
+    return content
+
+def grade_question(quiz, answer):
+    correct = (answer == quiz['correct_letter'])
+
+    if correct:
+        long_answer = quiz['answers'][answer]
+        response = '**CORRECT!** {long_answer} :tada:'.format(long_answer=long_answer)
+        return correct, response
+
+    response = '**WRONG!** {answer} is not correct :disappointed:'.format(answer=answer)
+    return correct, response
+
+
+handler_class = TriviaQuizHandler

--- a/zulip_bots/zulip_bots/bots/trivia_quiz/trivia_quiz.py
+++ b/zulip_bots/zulip_bots/bots/trivia_quiz/trivia_quiz.py
@@ -37,7 +37,7 @@ class TriviaQuizHandler:
                 bot_handler.send_reply(message, bot_response)
                 return
             try:
-                quiz_payload = bot_handler.storage.get(quiz_id)
+                quiz_payload = get_quiz_from_id(quiz_id, bot_handler)
             except KeyError:
                 bot_response = 'Invalid quiz id'
                 bot_handler.send_reply(message, bot_response)
@@ -51,6 +51,9 @@ class TriviaQuizHandler:
         else:
             bot_response = 'type "new" for a new question'
         bot_handler.send_reply(message, bot_response)
+
+def get_quiz_from_id(quiz_id: str, bot_handler: Any) -> str:
+    return bot_handler.storage.get(quiz_id)
 
 def start_new_quiz(message: Dict[str, Any], bot_handler: Any) -> None:
     quiz = get_trivia_quiz()

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -142,12 +142,13 @@ class ExternalBotHandler(object):
             self._rate_limit.show_error_and_exit()
         return self._client.send_message(message)
 
-    def send_reply(self, message: Dict[str, Any], response: str) -> Dict[str, Any]:
+    def send_reply(self, message: Dict[str, Any], response: str, widget_content: Optional[str]=None) -> Dict[str, Any]:
         if message['type'] == 'private':
             return self.send_message(dict(
                 type='private',
                 to=[x['email'] for x in message['display_recipient'] if self.email != x['email']],
                 content=response,
+                widget_content=widget_content,
             ))
         else:
             return self.send_message(dict(
@@ -155,6 +156,7 @@ class ExternalBotHandler(object):
                 to=message['display_recipient'],
                 subject=message['subject'],
                 content=response,
+                widget_content=widget_content,
             ))
 
     def update_message(self, message: Dict[str, Any]) -> Dict[str, Any]:

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -140,7 +140,10 @@ class ExternalBotHandler(object):
     def send_message(self, message: (Dict[str, Any])) -> Dict[str, Any]:
         if not self._rate_limit.is_legal():
             self._rate_limit.show_error_and_exit()
-        return self._client.send_message(message)
+        resp = self._client.send_message(message)
+        if resp.get('result') == 'error':
+            print("ERROR!: " + str(resp))
+        return resp
 
     def send_reply(self, message: Dict[str, Any], response: str, widget_content: Optional[str]=None) -> Dict[str, Any]:
         if message['type'] == 'private':

--- a/zulip_bots/zulip_bots/test_lib.py
+++ b/zulip_bots/zulip_bots/test_lib.py
@@ -1,6 +1,6 @@
 import unittest
 
-from typing import List, Dict, Any, Tuple
+from typing import List, Dict, Any, Tuple, Optional
 
 from zulip_bots.custom_exceptions import (
     ConfigValidationError,
@@ -41,9 +41,11 @@ class StubBotHandler:
         self.transcript.append(('send_message', message))
         return self.message_server.send(message)
 
-    def send_reply(self, message: Dict[str, Any], response: str) -> Dict[str, Any]:
+    def send_reply(self, message: Dict[str, Any], response: str,
+                   widget_content: Optional[str]=None) -> Dict[str, Any]:
         response_message = dict(
-            content=response
+            content=response,
+            widget_content=widget_content
         )
         self.transcript.append(('send_reply', response_message))
         return self.message_server.send(response_message)

--- a/zulip_bots/zulip_bots/tests/test_lib.py
+++ b/zulip_bots/zulip_bots/tests/test_lib.py
@@ -32,7 +32,9 @@ class FakeClient:
         )
 
     def send_message(self, message):
-        pass
+        return dict(
+            result='success',
+        )
 
 class FakeBotHandler:
     def usage(self):

--- a/zulip_bots/zulip_bots/tests/test_lib.py
+++ b/zulip_bots/zulip_bots/tests/test_lib.py
@@ -110,16 +110,17 @@ class LibTest(TestCase):
         )
         to = {'email': 'Some@User'}
         expected = [({'type': 'private', 'display_recipient': [to]},
-                     {'type': 'private', 'to': [to['email']]}),
+                     {'type': 'private', 'to': [to['email']]}, None),
                     ({'type': 'private', 'display_recipient': [to, profile]},
-                     {'type': 'private', 'to': [to['email']]}),
+                     {'type': 'private', 'to': [to['email']]}, 'widget_content'),
                     ({'type': 'stream', 'display_recipient': 'Stream name', 'subject': 'Topic'},
-                     {'type': 'stream', 'to': 'Stream name', 'subject': 'Topic'})]
+                     {'type': 'stream', 'to': 'Stream name', 'subject': 'Topic'}, 'test widget')]
         response_text = "Response"
         for test in expected:
             client.send_message = MagicMock()
-            handler.send_reply(test[0], response_text)
-            client.send_message.assert_called_once_with(dict(test[1], content=response_text))
+            handler.send_reply(test[0], response_text, test[2])
+            client.send_message.assert_called_once_with(dict(
+                test[1], content=response_text, widget_content=test[2]))
 
     def test_content_and_full_content(self):
         client = FakeClient()


### PR DESCRIPTION
Things changed from the original PR:
* tests in commit 1
* tests in commit 2
* Fixed lint errors in commit 3 (diff:)
```
--- a/zulip_bots/zulip_bots/bots/trivia_quiz/trivia_quiz.py
+++ b/zulip_bots/zulip_bots/bots/trivia_quiz/trivia_quiz.py
@@ -38,7 +38,7 @@ class TriviaQuizHandler:
                 return
             try:
                 quiz_payload = get_quiz_from_id(quiz_id)
-            except:
+            except KeyError:
                 bot_response = 'Invalid quiz id'
                 bot_handler.send_reply(message, bot_response)
                 return
@@ -132,10 +132,10 @@ def get_quiz_from_payload(payload):
 def generate_quiz_id(storage) -> str:
     try:
         quiz_num = storage.get('quiz_id')
-    except:
+    except KeyError:
         quiz_num = 0
     quiz_num += 1
-    quiz_num = quiz_num % 1000
+    quiz_num = quiz_num % (1000)
```

I am confused about one thing:
Upon sending `''` or `help` as the message, the bot replies `type "new" for a new question`, instead of displaying help. Should I fix this?