### PR TITLE
[WIP] Enable pytest as test-runner in API repo (test-bots only so far)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ twine
 coverage>=4.4.1
 pycodestyle==2.3.1
 mock
+pytest
 -e ./zulip
 -e ./zulip_bots
 -e ./zulip_botserver

--- a/tools/test-bots
+++ b/tools/test-bots
@@ -9,6 +9,7 @@ import argparse
 import glob
 import unittest
 from unittest import TestCase, TestSuite
+import pytest
 
 def parse_args():
     description = """
@@ -50,6 +51,14 @@ the tests for xkcd and wikipedia bots):
                         default=False,
                         action="store_true",
                         help="whether to exit if a bot has tests which won't run due to no __init__.py")
+    parser.add_argument('--pytest', '-p',
+                        default=False,
+                        action='store_true',
+                        help="run tests with pytest")
+    parser.add_argument('--verbose', '-v',
+                        default=False,
+                        action='store_true',
+                        help='show verbose output (with pytest)')
     return parser.parse_args()
 
 
@@ -80,28 +89,44 @@ def main():
 
     bots_to_test = filter(lambda bot: bot not in options.exclude, specified_bots)
 
-    # Codecov seems to work only when using loader.discover. It failed to
-    # capture line executions for functions like loader.loadTestFromModule
-    # or loader.loadTestFromNames.
-    top_level = "zulip_bots/zulip_bots/bots/"
-    loader = unittest.defaultTestLoader
-    test_suites = []
-    for name in bots_to_test:
-        try:
-            test_suites.append(loader.discover(top_level + name, top_level_dir=top_level))
-        except ImportError as exception:
-            print(exception)
-            print("This likely indicates that you need a '__init__.py' file in your bot directory.")
-            if options.error_on_no_init:
-                sys.exit(1)
+    if options.pytest:
+        excluded_bots = ['merels']
+        pytest_bots_to_test = sorted([bot for bot in bots_to_test if bot not in excluded_bots])
+        pytest_options = [
+            '-s',    # show output from tests; this hides the progress bar though
+            '-x',    # stop on first test failure
+            '--ff',  # runs last failure first
+        ]
+        pytest_options += (['-v'] if options.verbose else [])
+        os.chdir(bots_dir)
+        result = pytest.main(pytest_bots_to_test + pytest_options)
+        if result != 0:
+            sys.exit(1)
+        failures = False
+    else:
+        # Codecov seems to work only when using loader.discover. It failed to
+        # capture line executions for functions like loader.loadTestFromModule
+        # or loader.loadTestFromNames.
+        top_level = "zulip_bots/zulip_bots/bots/"
+        loader = unittest.defaultTestLoader
+        test_suites = []
+        for name in bots_to_test:
+            try:
+                test_suites.append(loader.discover(top_level + name, top_level_dir=top_level))
+            except ImportError as exception:
+                print(exception)
+                print("This likely indicates that you need a '__init__.py' file in your bot directory.")
+                if options.error_on_no_init:
+                    sys.exit(1)
 
-    suite = unittest.TestSuite(test_suites)
-    runner = unittest.TextTestRunner(verbosity=2)
-    result = runner.run(suite)
-    if result.failures or result.errors:
-        sys.exit(1)
+        suite = unittest.TestSuite(test_suites)
+        runner = unittest.TextTestRunner(verbosity=2)
+        result = runner.run(suite)
+        failures = result.failures
+        if failures or result.errors:
+            sys.exit(1)
 
-    if not result.failures and options.coverage:
+    if not failures and options.coverage:
         cov.stop()
         cov.data_suffix = False  # Disable suffix so that filename is .coverage
         cov.save()


### PR DESCRIPTION
This is a first step to explore how well pytest might work for the API repo in general; currently it only updates `test-bots`, though it is by far the more complex case of the test scripts.

In addition to using the test scripts explicitly, with pytest installed one can also run `pytest` or `pytest <path-to-tests>`, so `test-bots -p` is broadly equivalent to `pytest zulip_bots/zulip_bots/bots` except for some default settings. These default settings could be extracted into `pytest.ini` or similar files in an updated version of this commit or later. However, having the scripts too may remain useful if we adopt pytest.

The first commit uses test skipping to avoid testing the `BotTestCase` versions of the test functions; I've not found a way around this for pytest, but wanted a level playing field between unittest and pytest for the migration, so this commit also removes the filtering in `test-bots` which otherwise removed these tests from the test-suite.

The pytest case does not require the presence of `__init__.py` files unlike the unittest discovery process, so `test-bots` currently excludes the `merels` bot tests explicitly.

**Potential remaining issues**:
a) DIffering test discovery
* On `master`, `test-bots` claims 302 tests of which 4 are skipped (via unittest), those 4 being `monkeytestit`, leaving 298 passing tests.
* On this branch, `test-bots` claims 382 tests of which 84 are skipped (via unittest), leaving 298 passing tests.
* On this branch, `test-bots -p` claims 370 items of which 82 are skipped (via pytest), and 288 pass.

b) pytest appears to be slower in discovery ('collection'), at least currently, leading to longer (*reported*) run-times to run all tests:
* `test-bots`: 4.25, 4.43, 4.46, 4.58, 4.82, 4.93, 6.70
* `test-bots -p`: 8.49, 9.84, 10.92, 11.36, 11.40, 11.40, 13.98

**Overview**
Remaining issues notwithstanding, personally the experience with pytest is markedly better, including:
* easier style of pytest test writing (reduced verbosity, fixtures)
* test output clarity (eg. obvious that monkeytestit is where the multiple skips are)
* features (eg. only re-test last failure)

Of course, currently this just uses pytest as a test-runner, so we don't benefit from the first point.

I would love to hear what other people think!