### PR TITLE
bot tests: Allow raw responses in fixtures.

### DIFF
--- a/zulip_bots/zulip_bots/bots/trello/fixtures/invalid_key.json
+++ b/zulip_bots/zulip_bots/bots/trello/fixtures/invalid_key.json
@@ -1,0 +1,15 @@
+{
+  "meta": {
+    "is_raw_response": true
+  },
+  "request": {
+    "api_url": "https://api.trello.com/1/members/TEST/",
+    "params": {
+        "key": "TEST",
+        "token": "TEST"
+    }
+  },
+  "response": "invalid key",
+  "response-headers": {
+  }
+}

--- a/zulip_bots/zulip_bots/bots/trello/test_trello.py
+++ b/zulip_bots/zulip_bots/bots/trello/test_trello.py
@@ -27,7 +27,8 @@ class TestTrelloBot(BotTestCase):
 
     def test_bot_quit_with_invalid_config(self) -> None:
         with self.mock_config_info(mock_config), self.assertRaises(StubBotHandler.BotQuitException):
-            TrelloHandler().initialize(StubBotHandler())
+            with self.mock_http_conversation('invalid_key'):
+                TrelloHandler().initialize(StubBotHandler())
 
     def test_invalid_command(self) -> None:
         with self.mock_config_info(mock_config), patch('requests.get'):


### PR DESCRIPTION
Previously, the responses set in bot test fixtures
where handled as JSON objects. This works fine for
most bot tests, because ost of the APIs that bots
are calling return a JSON-formatted response object.
However, some, like Trello, do return raw data.
This hasn't been noticed so far, because the respective
Trello test needed internet access. Tests shouldn't
need internet access.
This commit makes that Trello test use a fixture. To
work properly, it also adds a way to make http_mock_config
parse the response object as raw data.
This can now be done by modifying the "is_raw_response"
property in a newly introduced "meta" object that can
be used to specify how a fixture should be handled.

@timabbott this should fix #411. 