### PR TITLE
Tests: Simplify & enable use of pytest to run all tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ pip-log.txt
 .tox
 nosetests.xml
 htmlcov/
+.pytest_cache
 
 # Translations
 *.mo

--- a/tools/server_lib/test_handler.py
+++ b/tools/server_lib/test_handler.py
@@ -9,8 +9,8 @@ import pytest
 TOOLS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.chdir(os.path.dirname(TOOLS_DIR))
 
-def handle_input_and_run_tests_for_package(package_name):
-    parser = argparse.ArgumentParser(description="Run tests for the {} package.".format(package_name))
+def handle_input_and_run_tests_for_package(package_name, path_list):
+    parser = argparse.ArgumentParser(description="Run tests for {}.".format(package_name))
     parser.add_argument('--coverage',
                         nargs='?',
                         const=True,
@@ -34,7 +34,7 @@ def handle_input_and_run_tests_for_package(package_name):
         cov.start()
 
     if options.pytest:
-        location_to_run_in = os.path.join(TOOLS_DIR, '..', package_name)
+        location_to_run_in = os.path.join(TOOLS_DIR, '..', *path_list)
         paths_to_test = ['.']
         pytest_options = [
             '-s',    # show output from tests; this hides the progress bar though
@@ -50,7 +50,7 @@ def handle_input_and_run_tests_for_package(package_name):
     else:
         # Codecov seems to work only when using loader.discover. It failed to capture line executions
         # for functions like loader.loadTestFromModule or loader.loadTestFromNames.
-        test_suites = unittest.defaultTestLoader.discover(package_name)
+        test_suites = unittest.defaultTestLoader.discover(os.path.join(*path_list))
         suite = unittest.TestSuite(test_suites)
         runner = unittest.TextTestRunner(verbosity=2)
         result = runner.run(suite)

--- a/tools/server_lib/test_handler.py
+++ b/tools/server_lib/test_handler.py
@@ -4,6 +4,7 @@ import os
 import sys
 import argparse
 import unittest
+import pytest
 
 TOOLS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.chdir(os.path.dirname(TOOLS_DIR))
@@ -15,6 +16,14 @@ def handle_input_and_run_tests_for_package(package_name):
                         const=True,
                         default=False,
                         help='compute test coverage (--coverage combine to combine with previous reports)')
+    parser.add_argument('--pytest', '-p',
+                        default=False,
+                        action='store_true',
+                        help="run tests with pytest")
+    parser.add_argument('--verbose', '-v',
+                        default=False,
+                        action='store_true',
+                        help='show verbose output (with pytest)')
     options = parser.parse_args()
 
     if options.coverage:
@@ -24,16 +33,32 @@ def handle_input_and_run_tests_for_package(package_name):
             cov.load()
         cov.start()
 
-    # Codecov seems to work only when using loader.discover. It failed to capture line executions
-    # for functions like loader.loadTestFromModule or loader.loadTestFromNames.
-    test_suites = unittest.defaultTestLoader.discover(package_name)
-    suite = unittest.TestSuite(test_suites)
-    runner = unittest.TextTestRunner(verbosity=2)
-    result = runner.run(suite)
-    if result.failures or result.errors:
-        sys.exit(1)
+    if options.pytest:
+        location_to_run_in = os.path.join(TOOLS_DIR, '..', package_name)
+        paths_to_test = ['.']
+        pytest_options = [
+            '-s',    # show output from tests; this hides the progress bar though
+            '-x',    # stop on first test failure
+            '--ff',  # runs last failure first
+        ]
+        pytest_options += (['-v'] if options.verbose else [])
+        os.chdir(location_to_run_in)
+        result = pytest.main(paths_to_test + pytest_options)
+        if result != 0:
+            sys.exit(1)
+        failures = False
+    else:
+        # Codecov seems to work only when using loader.discover. It failed to capture line executions
+        # for functions like loader.loadTestFromModule or loader.loadTestFromNames.
+        test_suites = unittest.defaultTestLoader.discover(package_name)
+        suite = unittest.TestSuite(test_suites)
+        runner = unittest.TextTestRunner(verbosity=2)
+        result = runner.run(suite)
+        failures = result.failures
+        if result.failures or result.errors:
+            sys.exit(1)
 
-    if not result.failures and options.coverage:
+    if not failures and options.coverage:
         cov.stop()
         cov.data_suffix = False  # Disable suffix so that filename is .coverage
         cov.save()

--- a/tools/server_lib/test_handler.py
+++ b/tools/server_lib/test_handler.py
@@ -5,6 +5,7 @@ import sys
 import argparse
 import unittest
 import pytest
+import shutil
 
 TOOLS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.chdir(os.path.dirname(TOOLS_DIR))
@@ -25,6 +26,10 @@ def handle_input_and_run_tests_for_package(package_name, path_list):
                         action='store_true',
                         help='show verbose output (with pytest)')
     options = parser.parse_args()
+
+    test_session_title = ' Running tests for {} '.format(package_name)
+    header = test_session_title.center(shutil.get_terminal_size().columns, '#')
+    print(header)
 
     if options.coverage:
         import coverage

--- a/tools/test-bots
+++ b/tools/test-bots
@@ -87,7 +87,9 @@ def main():
     else:
         specified_bots = available_bots
 
-    bots_to_test = filter(lambda bot: bot not in options.exclude, specified_bots)
+    # Use of a set ensures we don't end up with duplicate tests with unittest
+    # (from globbing multiple test_*.py files, or multiple on the command line)
+    bots_to_test = {bot for bot in specified_bots if bot not in options.exclude}
 
     if options.pytest:
         excluded_bots = ['merels']

--- a/tools/test-botserver
+++ b/tools/test-botserver
@@ -3,4 +3,4 @@
 from server_lib.test_handler import handle_input_and_run_tests_for_package
 
 if __name__ == '__main__':
-    handle_input_and_run_tests_for_package('zulip_botserver')
+    handle_input_and_run_tests_for_package('Botserver', ['zulip_botserver'])

--- a/tools/test-lib
+++ b/tools/test-lib
@@ -1,51 +1,6 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
-import os
-import sys
-import unittest
-import argparse
-
-from importlib import import_module
-
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--coverage',
-                        nargs='?',
-                        const=True,
-                        default=False,
-                        help='compute test coverage ("--coverage combine" to combine with previous reports)')
-    return parser.parse_args()
-
-def run_all():
-    TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
-    ROOT_DIR = os.path.abspath(os.path.join(TOOLS_DIR, '..'))
-    BOTS_DIR = os.path.join(ROOT_DIR, 'zulib_bots')
-    sys.path.insert(0, BOTS_DIR)
-
-    options = parse_args()
-
-    if options.coverage:
-        import coverage
-        cov = coverage.Coverage(config_file="tools/.coveragerc")
-        if options.coverage == 'combine':
-            cov.load()
-        cov.start()
-
-    module = 'zulip_bots/zulip_bots/tests/'
-    suite = unittest.defaultTestLoader.discover(module)
-
-    suite = unittest.TestSuite([suite])
-    runner = unittest.TextTestRunner(verbosity=2)
-    result = runner.run(suite)
-    if result.failures or result.errors:
-        sys.exit(1)
-
-    if not result.failures and options.coverage:
-        cov.stop()
-        cov.data_suffix = False  # Disable suffix so that filename is .coverage
-        cov.save()
-        cov.html_report()
-        print("HTML report saved under directory 'htmlcov'.")
+from server_lib.test_handler import handle_input_and_run_tests_for_package
 
 if __name__ == '__main__':
-    run_all()
+    handle_input_and_run_tests_for_package('Bot library', ['zulip_bots', 'zulip_bots', 'tests'])

--- a/tools/test-main
+++ b/tools/test-main
@@ -2,7 +2,7 @@
 
 set -ev
 
-tools/test-bots --coverage
-tools/test-botserver --coverage combine
-tools/test-zulip --coverage combine
-tools/test-lib --coverage combine
+tools/test-bots "$@" --coverage
+tools/test-botserver "$@" --coverage combine
+tools/test-zulip "$@" --coverage combine
+tools/test-lib "$@" --coverage combine

--- a/tools/test-zulip
+++ b/tools/test-zulip
@@ -3,4 +3,4 @@
 from server_lib.test_handler import handle_input_and_run_tests_for_package
 
 if __name__ == '__main__':
-    handle_input_and_run_tests_for_package('zulip')
+    handle_input_and_run_tests_for_package('API', ['zulip'])


### PR DESCRIPTION
This is a follow-up to #420, which completes the migration started there and tidies up the tests slightly.

Each test script run from `test-main`, and that script too, now support passing in `-p` to run via pytest, and also with `-v` to show each test.

I'm unsure if we'd like to see `-v` mode as the default; its output is similar to that from `unittest`, but can be verbose if the tests pass :)

`test-lib` is simplified a lot by using the common `test_handler` as in the other tests, with an amendment to that function, also comprising a header to nicely divide the test output.

If this all looks good, the pytest options can be factored out into a configuration file, but they're only in two locations right now.