### PR TITLE
Bot tests: Various tidying & minor improvements

### DIFF
--- a/zulip_bots/zulip_bots/bots/connect_four/test_connect_four.py
+++ b/zulip_bots/zulip_bots/bots/connect_four/test_connect_four.py
@@ -1,10 +1,8 @@
 from zulip_bots.test_lib import BotTestCase, DefaultTests
 
-from contextlib import contextmanager
-from unittest.mock import MagicMock
 from zulip_bots.bots.connect_four.connect_four import *
 from zulip_bots.game_handler import BadMoveException
-from typing import Dict, Any, List
+from typing import Dict, List
 
 
 class TestConnectFourBot(BotTestCase, DefaultTests):

--- a/zulip_bots/zulip_bots/bots/dialogflow/test_dialogflow.py
+++ b/zulip_bots/zulip_bots/bots/dialogflow/test_dialogflow.py
@@ -4,18 +4,9 @@ from contextlib import contextmanager
 
 from unittest.mock import patch
 
-from typing import Any, ByteString
+from typing import Iterator, ByteString
 
 import json
-
-class MockTextRequest():
-    def __init__(self) -> None:
-        self.session_id = ""
-        self.query = ""
-        self.response = ""
-
-    def getresponse(self) -> Any:
-        return MockHttplibRequest(self.response)
 
 class MockHttplibRequest():
     def __init__(self, response: str) -> None:
@@ -24,8 +15,17 @@ class MockHttplibRequest():
     def read(self) -> ByteString:
         return json.dumps(self.response).encode()
 
+class MockTextRequest():
+    def __init__(self) -> None:
+        self.session_id = ""
+        self.query = ""
+        self.response = ""
+
+    def getresponse(self) -> MockHttplibRequest:
+        return MockHttplibRequest(self.response)
+
 @contextmanager
-def mock_dialogflow(test_name: str, bot_name: str) -> Any:
+def mock_dialogflow(test_name: str, bot_name: str) -> Iterator[None]:
     response_data = read_bot_fixture_data(bot_name, test_name)
     try:
         df_request = response_data['request']

--- a/zulip_bots/zulip_bots/bots/dropbox_share/test_dropbox_share.py
+++ b/zulip_bots/zulip_bots/bots/dropbox_share/test_dropbox_share.py
@@ -1,5 +1,4 @@
 from zulip_bots.test_lib import BotTestCase, DefaultTests
-from typing import List
 from unittest.mock import patch
 
 from zulip_bots.bots.dropbox_share.test_util import (

--- a/zulip_bots/zulip_bots/bots/followup/test_followup.py
+++ b/zulip_bots/zulip_bots/bots/followup/test_followup.py
@@ -5,8 +5,6 @@ from zulip_bots.test_lib import (
     get_bot_message_handler,
 )
 
-from typing import Any
-
 
 class TestFollowUpBot(BotTestCase, DefaultTests):
     bot_name = "followup"

--- a/zulip_bots/zulip_bots/bots/game_handler_bot/test_game_handler_bot.py
+++ b/zulip_bots/zulip_bots/bots/game_handler_bot/test_game_handler_bot.py
@@ -1,8 +1,7 @@
 from zulip_bots.test_lib import BotTestCase, DefaultTests
 from zulip_bots.game_handler import GameInstance
 
-from contextlib import contextmanager
-from mock import MagicMock, patch
+from mock import patch
 
 from typing import Any, Dict, List
 

--- a/zulip_bots/zulip_bots/bots/game_of_fifteen/test_game_of_fifteen.py
+++ b/zulip_bots/zulip_bots/bots/game_of_fifteen/test_game_of_fifteen.py
@@ -1,10 +1,8 @@
 from zulip_bots.test_lib import BotTestCase, DefaultTests
 
-from contextlib import contextmanager
-from unittest.mock import MagicMock
 from zulip_bots.bots.game_of_fifteen.game_of_fifteen import GameOfFifteenModel
 from zulip_bots.game_handler import BadMoveException
-from typing import Dict, Any, List, Tuple
+from typing import Dict, List, Tuple
 
 
 class TestGameOfFifteenBot(BotTestCase, DefaultTests):

--- a/zulip_bots/zulip_bots/bots/giphy/test_giphy.py
+++ b/zulip_bots/zulip_bots/bots/giphy/test_giphy.py
@@ -1,7 +1,6 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from requests.exceptions import HTTPError, ConnectionError
 
-from typing import Any, Union
 from zulip_bots.test_lib import StubBotHandler, BotTestCase, DefaultTests, get_bot_message_handler
 
 class TestGiphyBot(BotTestCase, DefaultTests):

--- a/zulip_bots/zulip_bots/bots/github_detail/test_github_detail.py
+++ b/zulip_bots/zulip_bots/bots/github_detail/test_github_detail.py
@@ -5,8 +5,6 @@ from zulip_bots.test_lib import (
     get_bot_message_handler,
 )
 
-from typing import Any
-
 class TestGithubDetailBot(BotTestCase, DefaultTests):
     bot_name = "github_detail"
     mock_config = {'owner': 'zulip', 'repo': 'zulip'}

--- a/zulip_bots/zulip_bots/bots/help/test_help.py
+++ b/zulip_bots/zulip_bots/bots/help/test_help.py
@@ -1,7 +1,5 @@
 from zulip_bots.test_lib import BotTestCase, DefaultTests
 
-from typing import Any
-
 class TestHelpBot(BotTestCase, DefaultTests):
     bot_name = "help"
 

--- a/zulip_bots/zulip_bots/bots/idonethis/test_idonethis.py
+++ b/zulip_bots/zulip_bots/bots/idonethis/test_idonethis.py
@@ -2,8 +2,6 @@ from unittest.mock import patch
 
 from zulip_bots.test_lib import BotTestCase, DefaultTests
 
-import requests
-
 class TestIDoneThisBot(BotTestCase, DefaultTests):
     bot_name = "idonethis"  # type: str
 

--- a/zulip_bots/zulip_bots/bots/incrementor/test_incrementor.py
+++ b/zulip_bots/zulip_bots/bots/incrementor/test_incrementor.py
@@ -1,4 +1,4 @@
-from unittest import mock
+from unittest.mock import patch
 
 from zulip_bots.test_lib import (
     get_bot_message_handler,
@@ -19,7 +19,7 @@ class TestIncrementorBot(BotTestCase, DefaultTests):
         bot.initialize(bot_handler)
         bot.handle_message(message, bot_handler)
 
-        with mock.patch('zulip_bots.simple_lib.SimpleMessageServer.update') as m:
+        with patch('zulip_bots.simple_lib.SimpleMessageServer.update') as m:
             bot.handle_message(message, bot_handler)
             bot.handle_message(message, bot_handler)
             bot.handle_message(message, bot_handler)

--- a/zulip_bots/zulip_bots/bots/merels/test_merels.py
+++ b/zulip_bots/zulip_bots/bots/merels/test_merels.py
@@ -4,13 +4,9 @@ Most of the testing for the actual game are done in test_database
 This is only to really verify the output of the chat
 """
 
-from unittest import mock
+from zulip_bots.test_lib import BotTestCase, DefaultTests
 
-import zulip_bots.bots.merels.merels
-import zulip_bots.test_lib
-
-
-class TestFollowUpBot(zulip_bots.test_lib.BotTestCase, DefaultTests):
+class TestMerelsBot(BotTestCase, DefaultTests):
     bot_name = "merels"
 
     def test_no_command(self):

--- a/zulip_bots/zulip_bots/bots/monkeytestit/test_monkeytestit.py
+++ b/zulip_bots/zulip_bots/bots/monkeytestit/test_monkeytestit.py
@@ -1,4 +1,5 @@
-from unittest import mock, skipIf
+from unittest.mock import patch
+from unittest import skipIf
 
 from sys import version_info
 
@@ -18,7 +19,7 @@ class TestMonkeyTestitBot(BotTestCase, DefaultTests):
             content='',
             type='stream',
         )
-        with mock.patch.object(self.monkeytestit_class, 'initialize', return_value=None):
+        with patch.object(self.monkeytestit_class, 'initialize', return_value=None):
             with self.mock_config_info({'api_key': "magic"}):
                 res = self.get_response(message)
                 self.assertTrue("Unknown command" in res['content'])
@@ -28,7 +29,7 @@ class TestMonkeyTestitBot(BotTestCase, DefaultTests):
             content='check https://website.com',
             type='stream',
         )
-        with mock.patch.object(self.monkeytestit_class, 'initialize', return_value=None):
+        with patch.object(self.monkeytestit_class, 'initialize', return_value=None):
             with self.mock_config_info({'api_key': "magic"}):
                 with self.mock_http_conversation('website_result_fail'):
                     res = self.get_response(message)
@@ -39,7 +40,7 @@ class TestMonkeyTestitBot(BotTestCase, DefaultTests):
             content='check https://website.com',
             type='stream',
         )
-        with mock.patch.object(self.monkeytestit_class, 'initialize', return_value=None):
+        with patch.object(self.monkeytestit_class, 'initialize', return_value=None):
             with self.mock_config_info({'api_key': "magic"}):
                 with self.mock_http_conversation('website_result_success'):
                     res = self.get_response(message)

--- a/zulip_bots/zulip_bots/bots/monkeytestit/test_monkeytestit.py
+++ b/zulip_bots/zulip_bots/bots/monkeytestit/test_monkeytestit.py
@@ -1,13 +1,11 @@
-import unittest
-from unittest import mock
+from unittest import mock, skipIf
+
+from sys import version_info
 
 from importlib import import_module
 from zulip_bots.test_lib import BotTestCase, DefaultTests
 
-
-# TODO: Figure out a way to test bots that depends
-# on the Python version of the environment.
-@unittest.skip("Fails on Python3.4.")
+@skipIf(version_info[:2] < (3, 5), "monkeytestit requires python3.5+")
 class TestMonkeyTestitBot(BotTestCase, DefaultTests):
     bot_name = "monkeytestit"
 

--- a/zulip_bots/zulip_bots/bots/salesforce/test_salesforce.py
+++ b/zulip_bots/zulip_bots/bots/salesforce/test_salesforce.py
@@ -2,11 +2,11 @@ from zulip_bots.test_lib import BotTestCase, DefaultTests, StubBotHandler, read_
 from simple_salesforce.exceptions import SalesforceAuthenticationFailed
 from contextlib import contextmanager
 from unittest.mock import patch
-from typing import Any, Dict
+from typing import Any, Dict, Iterator
 
 
 @contextmanager
-def mock_salesforce_query(test_name: str, bot_name: str) -> Any:
+def mock_salesforce_query(test_name: str, bot_name: str) -> Iterator[None]:
     response_data = read_bot_fixture_data(bot_name, test_name)
     sf_response = response_data.get('response')
 
@@ -16,7 +16,7 @@ def mock_salesforce_query(test_name: str, bot_name: str) -> Any:
 
 
 @contextmanager
-def mock_salesforce_auth(is_success: bool) -> Any:
+def mock_salesforce_auth(is_success: bool) -> Iterator[None]:
     if is_success:
         with patch('simple_salesforce.api.Salesforce.__init__') as mock_sf_init:
             mock_sf_init.return_value = None
@@ -31,7 +31,7 @@ def mock_salesforce_auth(is_success: bool) -> Any:
 
 
 @contextmanager
-def mock_salesforce_commands_types() -> Any:
+def mock_salesforce_commands_types() -> Iterator[None]:
     with patch('zulip_bots.bots.salesforce.utils.commands', mock_commands), \
             patch('zulip_bots.bots.salesforce.utils.object_types', mock_object_types):
         yield

--- a/zulip_bots/zulip_bots/bots/salesforce/test_salesforce.py
+++ b/zulip_bots/zulip_bots/bots/salesforce/test_salesforce.py
@@ -1,10 +1,8 @@
 from zulip_bots.test_lib import BotTestCase, DefaultTests, StubBotHandler, read_bot_fixture_data
-import simple_salesforce
 from simple_salesforce.exceptions import SalesforceAuthenticationFailed
 from contextlib import contextmanager
 from unittest.mock import patch
 from typing import Any, Dict
-import logging
 
 
 @contextmanager

--- a/zulip_bots/zulip_bots/bots/susi/test_susi.py
+++ b/zulip_bots/zulip_bots/bots/susi/test_susi.py
@@ -3,8 +3,6 @@ from zulip_bots.test_lib import (
     DefaultTests,
 )
 
-from typing import Any
-
 class TestSusiBot(BotTestCase, DefaultTests):
     bot_name = "susi"
 

--- a/zulip_bots/zulip_bots/bots/tictactoe/test_tictactoe.py
+++ b/zulip_bots/zulip_bots/bots/tictactoe/test_tictactoe.py
@@ -1,7 +1,6 @@
 from zulip_bots.test_lib import BotTestCase, DefaultTests
 from zulip_bots.game_handler import GameInstance
 
-from unittest.mock import patch
 from typing import List, Tuple, Any
 
 

--- a/zulip_bots/zulip_bots/bots/twitpost/test_twitpost.py
+++ b/zulip_bots/zulip_bots/bots/twitpost/test_twitpost.py
@@ -9,9 +9,6 @@ from zulip_bots.test_file_utils import (
 )
 from unittest.mock import patch
 import tweepy
-import os
-import json
-
 
 class TestTwitpostBot(BotTestCase, DefaultTests):
     bot_name = "twitpost"

--- a/zulip_bots/zulip_bots/bots/witai/test_witai.py
+++ b/zulip_bots/zulip_bots/bots/witai/test_witai.py
@@ -1,5 +1,4 @@
 from unittest.mock import patch
-import sys
 from typing import Dict, Any, Optional
 from zulip_bots.test_lib import BotTestCase, DefaultTests, get_bot_message_handler, StubBotHandler
 

--- a/zulip_bots/zulip_bots/bots/xkcd/test_xkcd.py
+++ b/zulip_bots/zulip_bots/bots/xkcd/test_xkcd.py
@@ -1,4 +1,3 @@
-from unittest import mock
 from unittest.mock import MagicMock, patch
 from zulip_bots.test_lib import BotTestCase, DefaultTests
 
@@ -20,7 +19,7 @@ class TestXkcdBot(BotTestCase, DefaultTests):
         with self.mock_http_conversation('test_random'):
             # Mock randint function.
             with patch('zulip_bots.bots.xkcd.xkcd.random.randint') as randint:
-                mock_rand_value = mock.MagicMock()
+                mock_rand_value = MagicMock()
                 mock_rand_value.return_value = 1800
                 randint.return_value = mock_rand_value.return_value
                 self.verify_reply('random', bot_response)
@@ -31,8 +30,8 @@ class TestXkcdBot(BotTestCase, DefaultTests):
         with self.mock_http_conversation('test_specific_id'):
             self.verify_reply('1', bot_response)
 
-    @mock.patch('logging.exception')
-    def test_invalid_comic_ids(self, mock_logging_exception: mock.Mock) -> None:
+    @patch('logging.exception')
+    def test_invalid_comic_ids(self, mock_logging_exception: MagicMock) -> None:
         invalid_id_txt = "Sorry, there is likely no xkcd comic strip with id: #"
 
         for comic_id, fixture in (('0', 'test_not_existing_id_2'),

--- a/zulip_bots/zulip_bots/bots/youtube/test_youtube.py
+++ b/zulip_bots/zulip_bots/bots/youtube/test_youtube.py
@@ -2,7 +2,8 @@ from unittest.mock import patch
 from requests.exceptions import HTTPError, ConnectionError
 
 from zulip_bots.test_lib import StubBotHandler, BotTestCase, DefaultTests, get_bot_message_handler
-from typing import Any, Union, Dict
+from typing import Dict
+
 class TestYoutubeBot(BotTestCase, DefaultTests):
     bot_name = "youtube"
     normal_config  = {'key': '12345678',


### PR DESCRIPTION
* Improve typing in a few cases
* Remove quite a few unnecessary imports
* Use consistent imports within test files and across bots; the latter isn't vital, but the code is simpler
* Resolve the issue with `monkeytestit` not being tested since it fails for python 3.4
* Name the merels test better and improve it's style (though it is not currently being run)