### PR TITLE
api: Implement PATCH /streams/<stream_id>.

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -821,6 +821,18 @@ class Client(object):
             request=request,
         )
 
+    def update_stream(self, stream_data):
+        # type: (Dict[str, Any]) -> Dict[str, Any]
+        '''
+            See examples/edit-stream for example usage.
+        '''
+
+        return self.call_endpoint(
+            url='streams/{}'.format(stream_data['stream_id']),
+            method='PATCH',
+            request=stream_data,
+        )
+
     def get_members(self, request=None):
         # type: (Optional[Dict[str, Any]]) -> Dict[str, Any]
         '''

--- a/zulip/zulip/examples/edit-stream
+++ b/zulip/zulip/examples/edit-stream
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import argparse
+
+import zulip
+
+usage = """edit-stream --stream-id <stream_id>
+    [--description <new_description> --new-name <new_name>
+    --private --announcement-only --history-public-to-subscribers]
+
+Example: edit-stream --stream-id=42 --description="A city in Italy." \
+--new-name="Verona" --private
+Example: edit-stream --stream-id=3 --history-public-to-subscribers
+"""
+
+
+def quote(string):
+    # type: (str) -> str
+    return '"{}"'.format(string)
+
+
+parser = zulip.add_default_arguments(argparse.ArgumentParser(usage=usage))
+parser.add_argument('--stream-id', type=int, required=True)
+parser.add_argument('--description')
+parser.add_argument('--new-name')
+parser.add_argument('--private', action='store_true')
+parser.add_argument('--announcement-only', action='store_true')
+parser.add_argument('--history-public-to-subscribers', action='store_true')
+options = parser.parse_args()
+
+client = zulip.init_from_options(options)
+
+print(client.update_stream({
+    'stream_id': options.stream_id,
+    'description': quote(options.description),
+    'new_name': quote(options.new_name),
+    'is_private': options.private,
+    'is_announcement_only': options.announcement_only,
+    'history_public_to_subscribers': options.history_public_to_subscribers
+}))


### PR DESCRIPTION
**Testing plan:** lint and mypy checks passed locally.

About the quoting in the example, apparently the endpoint requires the strings to be quoted to be considered "valid JSON".