### PR TITLE
zulip_bots: Fix get_storage request arguments in StateHandler.

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -996,7 +996,7 @@ class Client(object):
             >>> client.update_storage({'storage': {"entry 1": "value 1", "entry 2": "value 2", "entry 3": "value 3"}})
             >>> client.get_storage()
             {'result': 'success', 'storage': {"entry 1": "value 1", "entry 2": "value 2", "entry 3": "value 3"}, 'msg': ''}
-            >>> client.get_storage(keys=('entry 1', 'entry 3'))
+            >>> client.get_storage({'keys': ["entry 1", "entry 3"]})
             {'result': 'success', 'storage': {'entry 1': 'value 1', 'entry 3': 'value 3'}, 'msg': ''}
         '''
         return self.call_endpoint(

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -69,7 +69,7 @@ class StateHandler(object):
         if key in self.state_:
             return self.demarshal(self.state_[key])
 
-        response = self._client.get_storage(keys=(key,))
+        response = self._client.get_storage({'keys': [key]})
         if response['result'] != 'success':
             raise StateHandlerError("Error fetching state: {}".format(str(response)))
 

--- a/zulip_bots/zulip_bots/tests/test_lib.py
+++ b/zulip_bots/zulip_bots/tests/test_lib.py
@@ -25,7 +25,7 @@ class FakeClient:
             result='success',
         )
 
-    def get_storage(self):
+    def get_storage(self, keys):
         return dict(
             result='success',
             storage=self.storage,
@@ -73,7 +73,7 @@ class LibTest(TestCase):
         val = state_handler.get('key')
         self.assertEqual(val, [1, 2, 3])
 
-    def test_state_handler(self):
+    def test_state_handler_by_mock(self):
         client = MagicMock()
 
         state_handler = StateHandler(client)

--- a/zulip_bots/zulip_bots/tests/test_lib.py
+++ b/zulip_bots/zulip_bots/tests/test_lib.py
@@ -25,7 +25,7 @@ class FakeClient:
             result='success',
         )
 
-    def get_storage(self, keys):
+    def get_storage(self, request):
         return dict(
             result='success',
             storage=self.storage,
@@ -92,7 +92,7 @@ class LibTest(TestCase):
             result='success',
             storage=dict(non_cached_key='[5]')))
         val = state_handler.get('non_cached_key')
-        client.get_storage.assert_called_with(keys=('non_cached_key',))
+        client.get_storage.assert_called_with({'keys': ['non_cached_key']})
         self.assertEqual(val, [5])
 
         # value must already be cached


### PR DESCRIPTION
I tried running `connect_four` game and it failed with these errors:
```
Traceback (most recent call last):
  File "/home/klitzy/python-zulip-api/zulip-api-py3-venv/bin/zulip-run-bot", line 11, in <module>
    load_entry_point('zulip-bots', 'console_scripts', 'zulip-run-bot')()
  File "/home/klitzy/python-zulip-api/zulip_bots/zulip_bots/run.py", line 123, in main
    bot_name=bot_name
  File "/home/klitzy/python-zulip-api/zulip_bots/zulip_bots/lib.py", line 300, in run_message_handler_for_bot
    message_handler = prepare_message_handler(bot_name, restricted_client, lib_module)
  File "/home/klitzy/python-zulip-api/zulip_bots/zulip_bots/lib.py", line 263, in prepare_message_handler
    message_handler.initialize(bot_handler=bot_handler)
  File "/home/klitzy/python-zulip-api/zulip_bots/zulip_bots/game_handler.py", line 180, in initialize
    self.get_user_cache()
  File "/home/klitzy/python-zulip-api/zulip_bots/zulip_bots/game_handler.py", line 642, in get_user_cache
    user_cache_str = self.bot_handler.storage.get('users')
  File "/home/klitzy/python-zulip-api/zulip_bots/zulip_bots/lib.py", line 72, in get
    response = self._client.get_storage(keys=(key,))
TypeError: get_storage() got an unexpected keyword argument 'keys'
```