### PR TITLE
[wip] Begin zgram support.

### DIFF
--- a/zulip/zulip/examples/send-zgram
+++ b/zulip/zulip/examples/send-zgram
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+import argparse
+import zulip
+
+usage = """send-zgram [options] <target_user_id>
+
+Sends a test zgram to the specified user.  (You must supply an id.)
+Then waits for zgram response.
+
+Example: send-zgram --content="hello"
+"""
+parser = zulip.add_default_arguments(argparse.ArgumentParser(usage=usage))
+parser.add_argument('target_user_id')
+parser.add_argument('--content', default='test zgram')
+options = parser.parse_args()
+
+client = zulip.init_from_options(options)
+res = client.register(event_types=['zgram'])
+queue_id = res['queue_id']
+last_event_id = res['last_event_id']
+
+request = dict(
+    data=dict(
+        target_user_id=int(options.target_user_id),
+        content=options.content,
+    ),
+)
+resp = client.call_endpoint(url='zgram', request=request)
+print(resp)
+
+print('\nStarting to wait for responses...\n')
+res = client.get_events(queue_id=queue_id, last_event_id=last_event_id)
+print(res)
+

--- a/zulip_bots/zulip_bots/bots/echo/echo.py
+++ b/zulip_bots/zulip_bots/bots/echo/echo.py
@@ -1,0 +1,24 @@
+from typing import Any, Dict
+
+class EchoHandler(object):
+    def usage(self) -> str:
+        return '''
+            This plugin will echo messages or zgrams back
+            to the sender.  This bot is mostly useful for
+            debugging bot infrastructure or doing sanity
+            checks for dev installs.
+            '''
+
+    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+        echo_content = 'echo: ' + message['content']
+        bot_handler.send_reply(message, echo_content)
+
+    def handle_zgram(self, data: Dict[str, Any], bot_handler: Any) -> None:
+        reply_content = 'echo: ' + data['content']
+        reply_data = dict(
+            target_user_id=data['sender_id'],
+            content=reply_content
+        )
+        bot_handler.send_zgram(reply_data)
+
+handler_class = EchoHandler

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -145,6 +145,11 @@ class ExternalBotHandler(object):
             print("ERROR!: " + str(resp))
         return resp
 
+    def send_zgram(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        request = dict(data=data)
+        resp = self._client.call_endpoint(url='zgram', request=request)
+        return resp
+
     def send_reply(self, message: Dict[str, Any], response: str, widget_content: Optional[str]=None) -> Dict[str, Any]:
         if message['type'] == 'private':
             return self.send_message(dict(
@@ -335,5 +340,14 @@ def run_message_handler_for_bot(
     def event_callback(event: Dict[str, Any]) -> None:
         if event['type'] == 'message':
             handle_message(event['message'], event['flags'])
+            return
 
-    client.call_on_each_event(event_callback, ['message'])
+        if event['type'] == 'zgram':
+            if hasattr(message_handler, 'handle_zgram'):
+                message_handler.handle_zgram(
+                    data=event['data'],
+                    bot_handler=restricted_client
+                )
+            return
+
+    client.call_on_each_event(event_callback, ['message', 'zgram'])


### PR DESCRIPTION
This still needs significant cleanup and, **more importantly**, it shouldn't be merged till we merge some of the server pieces.

But the first raw commit demonstrates the basic protocol where bots can both receive and send zgrams.