### PR TITLE
Fix post requests for JIRA bot

### DIFF
--- a/zulip_bots/zulip_bots/bots/jira/fixtures/test_create.json
+++ b/zulip_bots/zulip_bots/bots/jira/fixtures/test_create.json
@@ -3,10 +3,9 @@
     "api_url": "https://example.atlassian.net/rest/api/2/issue",
     "method": "POST",
     "headers": {
-      "Authorization": "Basic ZXhhbXBsZUBleGFtcGxlLmNvbTpxd2VydHkhMTIz",
-      "Content-type": "application/json"
+      "Authorization": "Basic ZXhhbXBsZUBleGFtcGxlLmNvbTpxd2VydHkhMTIz"
     },
-    "data": {
+    "json": {
       "fields": {
         "summary": "Testing",
         "project": { 

--- a/zulip_bots/zulip_bots/bots/jira/fixtures/test_create_error.json
+++ b/zulip_bots/zulip_bots/bots/jira/fixtures/test_create_error.json
@@ -3,10 +3,9 @@
     "api_url": "https://example.atlassian.net/rest/api/2/issue",
     "method": "POST",
     "headers": {
-      "Authorization": "Basic ZXhhbXBsZUBleGFtcGxlLmNvbTpxd2VydHkhMTIz",
-      "Content-type": "application/json"
+      "Authorization": "Basic ZXhhbXBsZUBleGFtcGxlLmNvbTpxd2VydHkhMTIz"
     },
-    "data": {
+    "json": {
       "fields": {
         "summary": "Testing",
         "project": { 

--- a/zulip_bots/zulip_bots/bots/jira/fixtures/test_edit.json
+++ b/zulip_bots/zulip_bots/bots/jira/fixtures/test_edit.json
@@ -3,10 +3,9 @@
     "api_url": "https://example.atlassian.net/rest/api/2/issue/TEST-16",
     "method": "PUT",
     "headers": {
-      "Authorization": "Basic ZXhhbXBsZUBleGFtcGxlLmNvbTpxd2VydHkhMTIz",
-      "Content-type": "application/json"
+      "Authorization": "Basic ZXhhbXBsZUBleGFtcGxlLmNvbTpxd2VydHkhMTIz"
     },
-    "data": {
+    "json": {
       "fields": {
         "description": "description"
       }

--- a/zulip_bots/zulip_bots/bots/jira/fixtures/test_edit_error.json
+++ b/zulip_bots/zulip_bots/bots/jira/fixtures/test_edit_error.json
@@ -3,10 +3,9 @@
     "api_url": "https://example.atlassian.net/rest/api/2/issue/TEST-13",
     "method": "PUT",
     "headers": {
-      "Authorization": "Basic ZXhhbXBsZUBleGFtcGxlLmNvbTpxd2VydHkhMTIz",
-      "Content-type": "application/json"
+      "Authorization": "Basic ZXhhbXBsZUBleGFtcGxlLmNvbTpxd2VydHkhMTIz"
     },
-    "data": {
+    "json": {
       "fields": {
         "summary": "Change the summary",
         "project": { 

--- a/zulip_bots/zulip_bots/bots/jira/jira.py
+++ b/zulip_bots/zulip_bots/bots/jira/jira.py
@@ -177,8 +177,8 @@ class JiraHandler(object):
         elif create_match:
             jira_response = requests.post(
                 self.domain_with_protocol + '/rest/api/2/issue',
-                headers={'Authorization': self.auth, 'Content-type': 'application/json'},
-                data=make_create_json(create_match.group('summary'),
+                headers={'Authorization': self.auth},
+                json=make_create_json(create_match.group('summary'),
                                       create_match.group('project_key'),
                                       create_match.group('type_name'),
                                       create_match.group('description'),
@@ -202,8 +202,8 @@ class JiraHandler(object):
 
             jira_response = requests.put(
                 self.domain_with_protocol + '/rest/api/2/issue/' + key,
-                headers={'Authorization': self.auth, 'Content-type': 'application/json'},
-                data=make_edit_json(edit_match.group('summary'),
+                headers={'Authorization': self.auth},
+                json=make_edit_json(edit_match.group('summary'),
                                     edit_match.group('project_key'),
                                     edit_match.group('type_name'),
                                     edit_match.group('description'),


### PR DESCRIPTION
JSON post requests aren't supposed to be form-encoded (see http://docs.python-requests.org/en/master/user/quickstart/#more-complicated-post-requests)