### PR TITLE
Fix bridge_with_irc

### DIFF
--- a/zulip/integrations/bridge_with_irc/irc-mirror.py
+++ b/zulip/integrations/bridge_with_irc/irc-mirror.py
@@ -21,6 +21,7 @@ Example:
 
 --stream is a Zulip stream.
 --topic is a Zulip topic, is optionally specified, defaults to "IRC".
+--nickserv-pw is a password for the nickserv, is optionally specified.
 
 Specify your Zulip API credentials and server in a ~/.zuliprc file or using the options.
 
@@ -35,6 +36,7 @@ if __name__ == "__main__":
     parser.add_argument('--channel', default=None)
     parser.add_argument('--stream', default="general")
     parser.add_argument('--topic', default="IRC")
+    parser.add_argument('--nickserv-pw', default='')
 
     options = parser.parse_args()
     # Setting the client to irc_mirror is critical for this to work
@@ -42,7 +44,7 @@ if __name__ == "__main__":
     zulip_client = zulip.init_from_options(options)
     try:
         from irc_mirror_backend import IRCBot
-    except ImportError as e:
+    except ImportError:
         traceback.print_exc()
         print("You have unsatisfied dependencies. Install all missing dependencies with "
               "{} --provision".format(sys.argv[0]))
@@ -52,5 +54,6 @@ if __name__ == "__main__":
         parser.error("Missing required argument")
 
     nickname = options.nick_prefix + "_zulip"
-    bot = IRCBot(zulip_client, options.stream, options.topic, options.channel, nickname, options.irc_server, options.port)
+    bot = IRCBot(zulip_client, options.stream, options.topic, options.channel,
+                 nickname, options.irc_server, options.nickserv_pw, options.port)
     bot.start()

--- a/zulip/integrations/bridge_with_irc/irc_mirror_backend.py
+++ b/zulip/integrations/bridge_with_irc/irc_mirror_backend.py
@@ -9,14 +9,16 @@ from typing import Any, Dict
 class IRCBot(irc.bot.SingleServerIRCBot):
     reactor_class = AioReactor
 
-    def __init__(self, zulip_client, stream, topic, channel, nickname, server, port=6667):
-        # type: (Any, str, str, irc.bot.Channel, str, str, int) -> None
+    def __init__(self, zulip_client, stream, topic, channel,
+                 nickname, server, nickserv_password='', port=6667):
+        # type: (Any, str, str, irc.bot.Channel, str, str, str, int) -> None
         irc.bot.SingleServerIRCBot.__init__(self, [(server, port)], nickname, nickname)
         self.channel = channel  # type: irc.bot.Channel
         self.zulip_client = zulip_client
         self.stream = stream
         self.topic = topic
         self.IRC_DOMAIN = server
+        self.nickserv_password = nickserv_password
 
     def zulip_sender(self, sender_string):
         # type: (str) -> str
@@ -38,6 +40,9 @@ class IRCBot(irc.bot.SingleServerIRCBot):
 
     def on_welcome(self, c, e):
         # type: (ServerConnection, Event) -> None
+        if len(self.nickserv_password) > 0:
+            msg = 'identify %s' % (self.nickserv_password,)
+            c.privmsg('NickServ', msg)
         c.join(self.channel)
 
         def forward_to_irc(msg):

--- a/zulip/integrations/bridge_with_irc/irc_mirror_backend.py
+++ b/zulip/integrations/bridge_with_irc/irc_mirror_backend.py
@@ -51,6 +51,7 @@ class IRCBot(irc.bot.SingleServerIRCBot):
                 in_the_specified_stream = msg["display_recipient"] == self.stream
                 at_the_specified_subject = msg["subject"].casefold() == self.topic.casefold()
                 if in_the_specified_stream and at_the_specified_subject:
+                    msg["content"] = ("@**%s**: " % msg["sender_full_name"]) + msg["content"]
                     send = lambda x: c.privmsg(self.channel, x)
                 else:
                     return


### PR DESCRIPTION
This fixes #106.
Can be tested with 
```
./irc-mirror.py --irc-server=irc.freenode.net --channel='#python-mypy' \
--nick-prefix='irc_mirror' \
--site="https://chat.zulip.org" --stream='test here' --topic='IRC' \
--user=<bot-email> --api-key=<bot-api-key>
```

Note the `--stream` arg is added here.