### PR TITLE
api: Rename "get_presence" to "get_user_presence".

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -989,12 +989,12 @@ class Client(object):
             request=request,
         )
 
-    def get_presence(self, email):
+    def get_user_presence(self, email):
         # type: (Dict[str, Any]) -> Dict[str, Any]
         '''
             Example usage:
 
-            >>> client.get_presence()
+            >>> client.get_user_presence('iago@zulip.com')
             {'presence': {'website': {'timestamp': 1486799122, 'status': 'active'}}, 'result': 'success', 'msg': ''}
         '''
         return self.call_endpoint(

--- a/zulip/zulip/examples/get-user-presence
+++ b/zulip/zulip/examples/get-user-presence
@@ -24,7 +24,7 @@
 from __future__ import print_function
 import argparse
 
-usage = """get-presence --email=<email address> [options]
+usage = """get-user-presence --email=<email address> [options]
 
 Get presence data for another user.
 """
@@ -37,4 +37,4 @@ options = parser.parse_args()
 
 client = zulip.init_from_options(options)
 
-print(client.get_presence(options.email))
+print(client.get_user_presence(options.email))


### PR DESCRIPTION
Given that this method fetches the presence status for a single user, the "get_presence" name should be reserved for the endpoint that gets the presence for all users.