### PR TITLE
provision: Refactor version tuple generation logic.

### DIFF
--- a/tools/provision
+++ b/tools/provision
@@ -36,7 +36,7 @@ the Python version this command is executed with."""
                                                 stderr=subprocess.STDOUT, universal_newlines=True)
     # The output has the format "Python 1.2.3"
     py_version_list = py_version_output.split()[1].split('.')
-    py_version = tuple(int(num) for num in py_version_list)
+    py_version = tuple(int(num) for num in py_version_list[0:2])
     venv_name = 'zulip-api-py{}-venv'.format(py_version[0])
 
     if py_version <= (3, 1) and (not options.force):


### PR DESCRIPTION
Previous tuple generation logic was throwing an error parsing version like 3.6.7rc1
because micro-versions like '7rc1' cannot be converted into integer.

Fix #482