### PR TITLE
bots: Fix a Chessbot dependency error.

### DIFF
--- a/tools/test-bots
+++ b/tools/test-bots
@@ -91,10 +91,6 @@ def main():
     # (from globbing multiple test_*.py files, or multiple on the command line)
     bots_to_test = {bot for bot in specified_bots if bot not in options.exclude}
 
-    # Temporary hack to get build running.  The chess bot didn't pin
-    # its dependency.
-    bots_to_test.discard('chessbot')
-
     if options.pytest:
         excluded_bots = ['merels']
         pytest_bots_to_test = sorted([bot for bot in bots_to_test if bot not in excluded_bots])

--- a/zulip_bots/zulip_bots/bots/chessbot/requirements.txt
+++ b/zulip_bots/zulip_bots/bots/chessbot/requirements.txt
@@ -1,1 +1,1 @@
-python-chess[engine,gaviota]
+python-chess[engine,gaviota] == 0.22.0


### PR DESCRIPTION
This PR specifies a version for Chessbot so that it will continue to function properly if the library is updated. This also updates `test-bots` to remove a temporary fix for Chessbot.