### PR TITLE
zulip/examples: Add a script to get complete history of a narrow.

### DIFF
--- a/zulip/zulip/examples/get-history
+++ b/zulip/zulip/examples/get-history
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+import argparse
+import json
+from typing import Dict, List, Any
+
+import zulip
+
+usage = """\nGets the complete history of a particular stream or a particular topic in Zulip
+and store them in JSON format.
+
+    get-history --stream <stream_name> [--topic <topic_name> --filename <file_to_store_messages>]
+
+Example: get-history --stream announce --topic important"""
+
+parser = zulip.add_default_arguments(argparse.ArgumentParser(usage=usage))
+parser.add_argument('--stream', required=True, help="The stream name to get the history")
+parser.add_argument('--topic', help="The topic name to get the history")
+parser.add_argument('--filename', default='history.json', help="The file name to store the fetched  \
+                    history.\n Default 'history.json'")
+options = parser.parse_args()
+
+client = zulip.init_from_options(options)
+
+narrow = [{'operator': 'stream', 'operand': options.stream}]
+if options.topic:
+    narrow.append({'operator': 'topic', 'operand': options.topic})
+
+request = {
+    # Initially we have the anchor as 0, so that it starts fetching
+    # from the oldest message in the narrow
+    'anchor': 0,
+    'num_before': 0,
+    'num_after': 1000,
+    'narrow': narrow,
+    'client_gravatar': False,
+    'apply_markdown': False
+}
+
+all_messages = []  # type: List[Dict[str, Any]]
+found_newest = False
+
+while not found_newest:
+    result = client.get_messages(request)
+    try:
+        found_newest = result["found_newest"]
+        if result['messages']:
+            # Setting the anchor to the next immediate message after the last fetched message.
+            request['anchor'] = result['messages'][-1]['id'] + 1
+
+            all_messages.extend(result["messages"])
+    except KeyError:
+        # Might occur when the request is not returned with a success status
+        print('Error occured: Payload was:')
+        print(result)
+        quit()
+
+with open(options.filename, "w+") as f:
+    print('Writing %d messages...' % len(all_messages))
+    f.write(json.dumps(all_messages))


### PR DESCRIPTION
This PR adds a script that can download the history of a stream or a topic from Zulip.

```
$ ./get-history --help
usage:
Gets the complete history of a particular stream or a particular topic in Zulip
and store them in JSON format.

    get-history --stream <stream_name> [--topic <topic_name> --filename <file_to_store_messages>]

Example: get-history --stream announce --topic important

optional arguments:
  -h, --help            show this help message and exit
  --stream STREAM       The stream name to get the history
  --topic TOPIC         The topic name to get the history
  --filename FILENAME   The file name to store the fetched history. Default
                        'history.json'
```


Written JSON file format :
```json
[
    {
        "content": "I am interested in working on #P476.\n\nIf I understand it correctly, the script should be able to download the complete history of any narrow(eg. : `stream:integrations sender:iago@zulip.com topic:test`)  and not just the `stream:stream-name` narrow, right ?",
        "client": "website",
        "stream_id": 127,
        "sender_realm_str": "",
        "flags": [
            "read"
        ],
        "id": 689524,
        "content_type": "text/x-markdown",
        "sender_id": 3893,
        "subject_links": [
            "https://github.com/zulip/python-zulip-api/pull/476"
        ],
        "recipient_id": 2643,
        "subject": "#P476",
        "display_recipient": "integrations",
        "sender_short_name": "siva.g.visakan",
        "avatar_url": "/user_avatars/2/786c599efd61bcb402d57e96488bd84d445d5aa6.png?x=x&version=2",
        "is_me_message": false,
        "sender_full_name": "Sivagiri Visakan",
        "type": "stream",
        "submessages": [],
        "sender_email": "siva.g.visakan@gmail.com",
        "reactions": [],
        "timestamp": 1548507562
    },
    {
        "client": "ZulipMobile",
        "stream_id": 127,
        "sender_realm_str": "",
        "flags": [
            "read"
        ],
        "content": "Yes I think so",
        "id": 689586,
        "content_type": "text/x-markdown",
        "sender_id": 58,
        "subject_links": [
            "https://github.com/zulip/python-zulip-api/pull/476"
        ],
        "sender_email": "showell@zulipchat.com",
        "subject": "#P476",
        "display_recipient": "integrations",
        "sender_short_name": "showell30",
        "avatar_url": "/user_avatars/2/0f93cc1fd329b3c4d1636c9ff168c524c66023b5.png?x=x&version=4",
        "is_me_message": false,
        "sender_full_name": "Steve Howell",
        "type": "stream",
        "submessages": [],
        "recipient_id": 2643,
        "reactions": [
            {
                "reaction_type": "unicode_emoji",
                "user": {
                    "full_name": "Sivagiri Visakan",
                    "email": "siva.g.visakan@gmail.com",
                    "id": 3893
                },
                "emoji_name": "+1",
                "emoji_code": "1f44d"
            }
        ],
        "timestamp": 1548522416
    }
]
```

Fixes #476.