### PR TITLE
API: Fix add_reaction method to pass reaction_data.

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -824,7 +824,7 @@ class Client(object):
         '''
             Example usage:
 
-            >>> client.add_emoji_reaction({
+            >>> client.add_reaction({
                 'message_id': '100',
                 'emoji_name': 'joy',
                 'emoji_code': '1f602',
@@ -835,6 +835,7 @@ class Client(object):
         return self.call_endpoint(
             url='messages/{}/reactions'.format(reaction_data['message_id']),
             method='POST',
+            request=reaction_data,
         )
 
     def remove_reaction(self, reaction_data):


### PR DESCRIPTION
Context: I'm in the process of migrating ZT to use 'full' API calls, rather than `do_api_query` or `call_endpoint`, which were necessary to call endpoints directly when the python API didn't have the functionality.

I wondered why the `add_reaction` method wasn't working; apparently the method doesn't pass the actual data to `call_endpoint`, so it's not really so surprising!

I also corrected the example usage text, which had an extra `emoji` in the method name.