### PR TITLE
Bots: Add support for running packaged bots via entrypoints

### DIFF
--- a/zulip_bots/setup.py
+++ b/zulip_bots/setup.py
@@ -55,6 +55,7 @@ setuptools_info = dict(
         'html2text',
         'lxml',
         'BeautifulSoup4',
+        'entrypoints',
     ],
 )
 

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -304,6 +304,7 @@ def run_message_handler_for_bot(
     config_file: str,
     bot_config_file: str,
     bot_name: str,
+    bot_source: str,
 ) -> Any:
     """
     lib_module is of type Any, since it can contain any bot's
@@ -334,7 +335,7 @@ def run_message_handler_for_bot(
     message_handler = prepare_message_handler(bot_name, restricted_client, lib_module)
 
     if not quiet:
-        print("Running {} Bot:".format(bot_details['name']))
+        print("Running {} Bot (from {}):".format(bot_details['name'], bot_source))
         if bot_details['description'] != "":
             print("\n\t{}".format(bot_details['description']))
         print(message_handler.usage())

--- a/zulip_bots/zulip_bots/run.py
+++ b/zulip_bots/zulip_bots/run.py
@@ -123,16 +123,18 @@ def main() -> None:
                            "    zulip-run-bot {bot_name} --provision")
             print(dep_err_msg.format(bot_name=bot_name, deps_list=deps_list))
             sys.exit(1)
+        bot_source = "source"
     else:
         lib_module = finder.import_module_by_name(args.bot)
         if lib_module:
             bot_name = lib_module.__name__
+            bot_source = "named module"
             if args.provision:
                 print("ERROR: Could not load bot's module for '{}'. Exiting now.")
                 sys.exit(1)
         else:
             try:
-                lib_module = finder.import_module_from_zulip_bot_registry(args.bot)
+                bot_source, lib_module = finder.import_module_from_zulip_bot_registry(args.bot)
             except finder.DuplicateRegisteredBotName as e:
                 print("ERROR: Found duplicate entries for bot name in zulip bot registry. Exiting now.")
                 sys.exit(1)
@@ -158,7 +160,8 @@ def main() -> None:
             config_file=args.config_file,
             bot_config_file=args.bot_config_file,
             quiet=args.quiet,
-            bot_name=bot_name
+            bot_name=bot_name,
+            bot_source=bot_source,
         )
     except NoBotConfigException:
         print('''

--- a/zulip_bots/zulip_bots/run.py
+++ b/zulip_bots/zulip_bots/run.py
@@ -130,6 +130,14 @@ def main() -> None:
             if args.provision:
                 print("ERROR: Could not load bot's module for '{}'. Exiting now.")
                 sys.exit(1)
+        else:
+            try:
+                lib_module = finder.import_module_from_zulip_bot_registry(args.bot)
+            except finder.DuplicateRegisteredBotName as e:
+                print("ERROR: Found duplicate entries for bot name in zulip bot registry. Exiting now.")
+                sys.exit(1)
+            if lib_module:
+                bot_name = args.bot
 
     if lib_module is None:
         print("ERROR: Could not load bot module. Exiting now.")

--- a/zulip_bots/zulip_bots/tests/test_lib.py
+++ b/zulip_bots/zulip_bots/tests/test_lib.py
@@ -174,7 +174,8 @@ class LibTest(TestCase):
                                         quiet=True,
                                         config_file=None,
                                         bot_config_file=None,
-                                        bot_name='testbot')
+                                        bot_name='testbot',
+                                        bot_source='bot code location')
 
     def test_upload_file(self):
         client, handler = self._create_client_and_handler_for_file_upload()

--- a/zulip_bots/zulip_bots/tests/test_run.py
+++ b/zulip_bots/zulip_bots/tests/test_run.py
@@ -16,7 +16,8 @@ class TestDefaultArguments(TestCase):
 
     our_dir = os.path.dirname(__file__)
     path_to_bot = os.path.abspath(os.path.join(our_dir, '../bots/giphy/giphy.py'))
-    packaged_bot_entrypoint = entrypoints.EntryPoint("packaged_bot", "module_name", None)
+    packaged_bot_distro = entrypoints.Distribution("packaged-bot-source", "1.0.0")
+    packaged_bot_entrypoint = entrypoints.EntryPoint("packaged_bot", "module_name", None, distro=packaged_bot_distro)
 
     @patch('sys.argv', ['zulip-run-bot', 'giphy', '--config-file', '/foo/bar/baz.conf'])
     @patch('zulip_bots.run.run_message_handler_for_bot')
@@ -28,6 +29,7 @@ class TestDefaultArguments(TestCase):
                                                             config_file='/foo/bar/baz.conf',
                                                             bot_config_file=None,
                                                             lib_module=mock.ANY,
+                                                            bot_source='source',
                                                             quiet=False)
 
     @patch('sys.argv', ['zulip-run-bot', path_to_bot, '--config-file', '/foo/bar/baz.conf'])
@@ -41,6 +43,7 @@ class TestDefaultArguments(TestCase):
             config_file='/foo/bar/baz.conf',
             bot_config_file=None,
             lib_module=mock.ANY,
+            bot_source='source',
             quiet=False)
 
     @patch('sys.argv', ['zulip-run-bot', 'packaged_bot', '--config-file', '/foo/bar/baz.conf'])
@@ -56,6 +59,7 @@ class TestDefaultArguments(TestCase):
             config_file='/foo/bar/baz.conf',
             bot_config_file=None,
             lib_module=mock.ANY,
+            bot_source='packaged-bot-source: 1.0.0',
             quiet=False)
 
     def test_adding_bot_parent_dir_to_sys_path_when_bot_name_specified(self) -> None:

--- a/zulip_bots/zulip_bots/tests/test_run.py
+++ b/zulip_bots/zulip_bots/tests/test_run.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+import entrypoints
 import zulip_bots.run
 from zulip_bots.lib import extract_query_without_mention
 import unittest
@@ -15,6 +16,7 @@ class TestDefaultArguments(TestCase):
 
     our_dir = os.path.dirname(__file__)
     path_to_bot = os.path.abspath(os.path.join(our_dir, '../bots/giphy/giphy.py'))
+    packaged_bot_entrypoint = entrypoints.EntryPoint("packaged_bot", "module_name", None)
 
     @patch('sys.argv', ['zulip-run-bot', 'giphy', '--config-file', '/foo/bar/baz.conf'])
     @patch('zulip_bots.run.run_message_handler_for_bot')
@@ -36,6 +38,21 @@ class TestDefaultArguments(TestCase):
 
         mock_run_message_handler_for_bot.assert_called_with(
             bot_name='giphy',
+            config_file='/foo/bar/baz.conf',
+            bot_config_file=None,
+            lib_module=mock.ANY,
+            quiet=False)
+
+    @patch('sys.argv', ['zulip-run-bot', 'packaged_bot', '--config-file', '/foo/bar/baz.conf'])
+    @patch('zulip_bots.run.run_message_handler_for_bot')
+    def test_argument_parsing_with_zulip_bot_registry(self, mock_run_message_handler_for_bot: mock.Mock) -> None:
+        with patch('zulip_bots.run.exit_gracefully_if_zulip_config_is_missing'):
+            with patch('zulip_bots.finder.entrypoints.EntryPoint.load'):
+                with patch('zulip_bots.finder.entrypoints.get_group_all', return_value = [self.packaged_bot_entrypoint]):
+                    zulip_bots.run.main()
+
+        mock_run_message_handler_for_bot.assert_called_with(
+            bot_name='packaged_bot',
             config_file='/foo/bar/baz.conf',
             bot_config_file=None,
             lib_module=mock.ANY,


### PR DESCRIPTION
The entrypoints approach seems like it may make it easier to produce third-party bots, and could potentially be extended to be the default way in which `zulip_bots` accesses built-in bots?

A test is included for the new approach, as well as:
- removal of python 3.4 support and addition of 3.7 to travis (branch failed due to an existing bot requiring lxml with 2.7 or >=3.5)
- addition of `ImportError` as an alternative to `ModuleNotFoundError`, which is only introduced in python 3.6
- changes to improve indication to the user, where the bot module is being sourced