### PR TITLE
Restore dependency on typing package for Python < 3.5

### DIFF
--- a/zulip/setup.py
+++ b/zulip/setup.py
@@ -56,6 +56,7 @@ package_info = dict(
 setuptools_info = dict(
     install_requires=['requests[security]>=0.12.1',
                       'six',
+                      'typing>=3.5.2.2;python_version<"3.5"',
                       'matrix_client',
                       ],
 )


### PR DESCRIPTION
Apparently we still support Python 2.7 for some reason.

Follow-up to #521.