### PR TITLE
rss-bot: Updated link pointing to .zuliprc

### DIFF
--- a/zulip/integrations/rss/rss-bot
+++ b/zulip/integrations/rss/rss-bot
@@ -52,7 +52,7 @@ To use this script:
 1. Create an RSS feed file containing 1 feed URL per line (default feed
    file location: ~/.cache/zulip-rss/rss-feeds)
 2. Subscribe to the stream that will receive RSS updates (default stream: rss)
-3. create a ~/.zuliprc as described on https://zulipchat.com/api#api_keys
+3. create a ~/.zuliprc as described on https://zulipchat.com/api/configuring-python-bindings
 4. Test the script by running it manually, like this:
 
 /usr/local/share/zulip/integrations/rss/rss-bot


### PR DESCRIPTION
I believe that rss-bot is pointing to wrong page on documentation, this MR should fix it.

Signed-off-by: Jacob Hrbek <werifgx@gmail.com>