### PR TITLE
zulip: Use distro.linux_distribution instead of platform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ coverage>=4.4.1
 pycodestyle==2.3.1
 mock
 pytest
+distro
 -e ./zulip
 -e ./zulip_bots
 -e ./zulip_botserver

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -36,6 +36,7 @@ import random
 import types
 from distutils.version import LooseVersion
 
+import distro
 from six.moves.configparser import SafeConfigParser
 from six.moves import urllib
 import logging
@@ -463,7 +464,7 @@ class Client(object):
             pass
 
         if vendor == "Linux":
-            vendor, vendor_version, dummy = platform.linux_distribution()
+            vendor, vendor_version, dummy = distro.linux_distribution()
         elif vendor == "Windows":
             vendor_version = platform.win32_ver()[1]
         elif vendor == "Darwin":


### PR DESCRIPTION
Python 3.8 removes `platform.linux_distribution` and `distro` is the
recommended replacement to use for this function.