### PR TITLE
zulip: Move dependency on distro into zulip package.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ coverage>=4.4.1
 pycodestyle==2.3.1
 mock
 pytest
-distro
 -e ./zulip
 -e ./zulip_bots
 -e ./zulip_botserver

--- a/zulip/setup.py
+++ b/zulip/setup.py
@@ -65,6 +65,7 @@ setuptools_info = dict(
                       'six',
                       'typing>=3.5.2.2;python_version<"3.5"',
                       'matrix_client',
+                      'distro',
                       ],
 )
 


### PR DESCRIPTION
The just-released API package has a significant issue, which doesn't install the `distro` package as a dependency of the `zulip` package directly.

This small (but important) PR should fix that.

@eeshangarg @timabbott 