### PR TITLE
twitter: Add support for phrase.

### DIFF
--- a/zulip/integrations/twitter/twitter-bot
+++ b/zulip/integrations/twitter/twitter-bot
@@ -243,6 +243,10 @@ for status in statuses[::-1][:opts.limit_tweets]:
     if opts.search_terms:
         search_term_used = None
         for term in opts.search_terms.split(","):
+            # Remove quotes from phrase:
+            #   "Zulip API" -> Zulip API
+            if term.startswith('"') and term.endswith('"'):
+                term = term[1:-1]
             if any(term.lower() in text for text in text_to_check):
                 search_term_used = term
                 break


### PR DESCRIPTION
Twitter supports phrase search by quoting terms such as "Zulip API".

If we use the feature, the current twitter-bot can't detect used
search phrase. We can detect used search phrase with this change.