### PR TITLE
bridge_with_irc: Print message on successful connection.

### DIFF
--- a/zulip/integrations/bridge_with_irc/irc_mirror_backend.py
+++ b/zulip/integrations/bridge_with_irc/irc_mirror_backend.py
@@ -33,6 +33,7 @@ class IRCBot(irc.bot.SingleServerIRCBot):
         self.reactor.loop.run_until_complete(
             self.connection.connect(*args, **kwargs)
         )
+        print("Connected to IRC server.")
 
     def on_nicknameinuse(self, c, e):
         # type: (ServerConnection, Event) -> None


### PR DESCRIPTION
If no error occurred then bridge_with_irc shows no output on the terminal and users don't know if they are connected to the irc server or not. Add an output line after connection so that a message appears if connection to irc server has been successful.