### PR TITLE
api: Refactor get_subscribers to accept stream_id as well

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -1322,12 +1322,17 @@ class Client(object):
         # type: (**Any) -> Dict[str, Any]
         '''
             Example usage: client.get_subscribers(stream='devel')
+            OR
+            client.get_subscribers(stream_id=1)
         '''
-        response = self.get_stream_id(request['stream'])
-        if response['result'] == 'error':
-            return response
+        if 'stream_id' in request.keys():
+            stream_id = request['stream_id']
+        else:
+            response = self.get_stream_id(request['stream'])
+            if response['result'] == 'error':
+                return response
+            stream_id = response['stream_id']
 
-        stream_id = response['stream_id']
         url = 'streams/%d/members' % (stream_id,)
         return self.call_endpoint(
             url=url,


### PR DESCRIPTION
This refactors get_subscribers method to accept stream_id as well to return the subscribers of a stream.