### PR TITLE
bridge_with_irc: Make bridge more user-friendly.

### DIFF
--- a/zulip/integrations/bridge_with_irc/irc_mirror_backend.py
+++ b/zulip/integrations/bridge_with_irc/irc_mirror_backend.py
@@ -12,7 +12,6 @@ class IRCBot(irc.bot.SingleServerIRCBot):
     def __init__(self, zulip_client, stream, topic, channel,
                  nickname, server, nickserv_password='', port=6667):
         # type: (Any, str, str, irc.bot.Channel, str, str, str, int) -> None
-        irc.bot.SingleServerIRCBot.__init__(self, [(server, port)], nickname, nickname)
         self.channel = channel  # type: irc.bot.Channel
         self.zulip_client = zulip_client
         self.stream = stream
@@ -21,6 +20,8 @@ class IRCBot(irc.bot.SingleServerIRCBot):
         self.nickserv_password = nickserv_password
         # Make sure the bot is subscribed to the stream
         self.check_subscription_or_die()
+        # Initialize IRC bot after proper connection to Zulip server has been confirmed.
+        irc.bot.SingleServerIRCBot.__init__(self, [(server, port)], nickname, nickname)
 
     def zulip_sender(self, sender_string):
         # type: (str) -> str

--- a/zulip/integrations/bridge_with_irc/irc_mirror_backend.py
+++ b/zulip/integrations/bridge_with_irc/irc_mirror_backend.py
@@ -35,15 +35,18 @@ class IRCBot(irc.bot.SingleServerIRCBot):
         self.reactor.loop.run_until_complete(
             self.connection.connect(*args, **kwargs)
         )
-        print("Connected to IRC server.")
+        print("Listening now. Please send an IRC message to verify operation")
 
     def check_subscription_or_die(self):
         # type: () -> None
         resp = self.zulip_client.list_subscriptions()
-        assert resp["result"] == "success"
+        if resp["result"] != "success":
+            print("ERROR: %s" % (resp["msg"],))
+            exit(1)
         subs = [s["name"] for s in resp["subscriptions"]]
         if self.stream not in subs:
-            raise Exception("The bot is not yet subscribed to the specified stream")
+            print("The bot is not yet subscribed to stream '%s'. Please subscribe the bot to the stream first." % (self.stream,))
+            exit(1)
 
     def on_nicknameinuse(self, c, e):
         # type: (ServerConnection, Event) -> None


### PR DESCRIPTION
Edit error and success messages of zulip-irc bridge to be more
user friendly. Also check whether zulip bot is subscribed before
starting irc bot.