### PR TITLE
bridges: Remove sender field from message data.

### DIFF
--- a/zulip/integrations/bridge_between_zulips/run-interrealm-bridge
+++ b/zulip/integrations/bridge_between_zulips/run-interrealm-bridge
@@ -39,7 +39,6 @@ def create_pipe_event(to_client: zulip.Client, from_bot: Dict[str, Any],
                 # formatting purpose
                 msg["content"] = "\n" + msg["content"]
             msg_data = {
-                "sender": to_client.email,
                 "type": "stream",
                 "to": to_bot["stream"],
                 "subject": subject,

--- a/zulip/integrations/bridge_with_matrix/matrix_bridge.py
+++ b/zulip/integrations/bridge_with_matrix/matrix_bridge.py
@@ -81,7 +81,6 @@ def matrix_to_zulip(zulip_client, zulip_config, matrix_config, no_noise):
         if not_from_zulip_bot and content:
             try:
                 result = zulip_client.send_message({
-                    "sender": zulip_client.email,
                     "type": "stream",
                     "to": zulip_config["stream"],
                     "subject": zulip_config["topic"],


### PR DESCRIPTION
For the reason why, see https://chat.zulip.org/#narrow/stream/127-integrations/topic/bridge.20between.20zulips.