### PR TITLE
api: Refactor get_user_by_id to take keyword arguments

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -1053,13 +1053,13 @@ class Client(object):
             method='DELETE',
         )
 
-    def get_user_by_id(self, user_id, request=None):
-        # type: (int, Optional[Dict[str, Any]]) -> Dict[str, Any]
+    def get_user_by_id(self, user_id, **request):
+        # type: (int, **Any) -> Dict[str, Any]
 
         '''
             Example usage:
 
-            >>> client.get_user_by_id(8, {'include_custom_profile_fields': True})
+            >>> client.get_user_by_id(8, include_custom_profile_fields=True)
             {'result': 'success', 'msg': '', 'user': [{...}, {...}]}
         '''
         return self.call_endpoint(


### PR DESCRIPTION
This refactors get_user_by_id to take arguments like
`include_custom_profile_fields = True` instead of
{include_custom_profile_fields: True}.