### PR TITLE
finder: Remove ModuleNotFoundError handler

### DIFF
--- a/zulip_bots/zulip_bots/finder.py
+++ b/zulip_bots/zulip_bots/finder.py
@@ -29,8 +29,6 @@ def import_module_by_name(name: Text) -> Any:
         return importlib.import_module(name)
     except ImportError:
         return None
-    except ModuleNotFoundError:  # Specific exception supported >=Python3.6
-        return None
 
 def resolve_bot_path(name: Text) -> Optional[Tuple[Text, Text]]:
     if os.path.isfile(name):


### PR DESCRIPTION
`ModuleNotFoundError` is a subclass of `ImportError`, which is handled on the previous line; furthermore, it doesn’t exist in Python 3.5.