### PR TITLE
ExternalBotHandler: Support adding reactions to message for a bot..

### DIFF
--- a/zulip_bots/zulip_bots/bots/helloworld/helloworld.py
+++ b/zulip_bots/zulip_bots/bots/helloworld/helloworld.py
@@ -16,4 +16,8 @@ class HelloWorldHandler:
         content = 'beep boop'  # type: str
         bot_handler.send_reply(message, content)
 
+        emoji_name = 'wave'    # type: str
+        bot_handler.react(message, emoji_name)
+        return
+
 handler_class = HelloWorldHandler

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -153,6 +153,11 @@ class ExternalBotHandler:
     def identity(self) -> BotIdentity:
         return BotIdentity(self.full_name, self.email)
 
+    def react(self, message: Dict[str, Any], emoji_name: str) -> Dict[str, Any]:
+        return self._client.add_reaction(dict(message_id=message['id'],
+                                              emoji_name=emoji_name,
+                                              reaction_type='unicode_emoji'))
+
     def send_message(self, message: (Dict[str, Any])) -> Dict[str, Any]:
         if not self._rate_limit.is_legal():
             self._rate_limit.show_error_and_exit()

--- a/zulip_bots/zulip_bots/simple_lib.py
+++ b/zulip_bots/zulip_bots/simple_lib.py
@@ -30,6 +30,9 @@ class SimpleMessageServer:
         self.messages[self.message_id] = message
         return message
 
+    def add_reaction(self, reaction_data):
+        return dict(result='success', msg='', uri='https://server/messages/{}/reactions'.format(uuid4()))
+
     def update(self, message):
         self.messages[message['message_id']] = message
 

--- a/zulip_bots/zulip_bots/test_lib.py
+++ b/zulip_bots/zulip_bots/test_lib.py
@@ -50,6 +50,9 @@ class StubBotHandler:
         self.transcript.append(('send_reply', response_message))
         return self.message_server.send(response_message)
 
+    def react(self, message: Dict[str, Any], emoji_name: str) -> Dict[str, Any]:
+        return self.message_server.add_reaction(emoji_name)
+
     def update_message(self, message: Dict[str, Any]) -> None:
         self.message_server.update(message)
 

--- a/zulip_bots/zulip_bots/tests/test_lib.py
+++ b/zulip_bots/zulip_bots/tests/test_lib.py
@@ -107,6 +107,21 @@ class LibTest(TestCase):
         client.get_storage.assert_not_called()
         self.assertEqual(val, [5])
 
+    def test_react(self):
+        client = FakeClient()
+        handler = ExternalBotHandler(
+            client = client,
+            root_dir=None,
+            bot_details=None,
+            bot_config_file=None
+        )
+        emoji_name = 'wave'
+        message = {'id': 10}
+        expected = {'message_id': message['id'], 'emoji_name': 'wave', 'reaction_type': 'unicode_emoji'}
+        client.add_reaction = MagicMock()
+        handler.react(message, emoji_name)
+        client.add_reaction.assert_called_once_with(dict(expected))
+
     def test_send_reply(self):
         client = FakeClient()
         profile = client.get_profile()


### PR DESCRIPTION
This adds a react() function that allows a bot to react to a message with an example and tests.