### PR TITLE
Add search and JQL functions to Jira bot

### DIFF
--- a/zulip_bots/zulip_bots/bots/jira/doc.md
+++ b/zulip_bots/zulip_bots/bots/jira/doc.md
@@ -2,12 +2,13 @@
 
 ## Setup
 
-To use Jira Bot, first set up `jira.conf`. `jira.conf` takes 3 options:
+To use Jira Bot, first set up `jira.conf`. `jira.conf` requires 3 options:
 
  - username (an email or username that can access your Jira),
  - password (the password for that username), and
  - domain (a domain like `example.atlassian.net`)
- - display_url ([optional] your front facing jira URL if different from domain. E.g. `https://example-lb.atlassian.net`)
+ - display_url ([optional] your front facing jira URL if different from domain.
+E.g. `https://example-lb.atlassian.net`)
 
 ## Usage
 

--- a/zulip_bots/zulip_bots/bots/jira/doc.md
+++ b/zulip_bots/zulip_bots/bots/jira/doc.md
@@ -48,6 +48,25 @@ Jira Bot:
 
 ---
 
+### jql
+
+`jql` takes in a jql search string and returns matching issues. For example,
+
+you:
+
+ > @**Jira Bot** jql "issuetype = Engagement ORDER BY created DESC"
+
+Jira Bot:
+
+ > **Search results for "issuetype = vulnerability ORDER BY created DESC"**
+ >
+ > *Found 53 results*
+ >
+ > - ***BOTS-1:*** External Website Test **[In Progress]**
+ > - ***BOTS-3:*** Network Vulnerability Scan **[Draft]**
+
+---
+
 ### create
 
 `create` creates an issue using its

--- a/zulip_bots/zulip_bots/bots/jira/doc.md
+++ b/zulip_bots/zulip_bots/bots/jira/doc.md
@@ -7,6 +7,7 @@ To use Jira Bot, first set up `jira.conf`. `jira.conf` takes 3 options:
  - username (an email or username that can access your Jira),
  - password (the password for that username), and
  - domain (a domain like `example.atlassian.net`)
+ - display_url ([optional] your front facing jira URL if different from domain. E.g. `https://example-lb.atlassian.net`)
 
 ## Usage
 
@@ -29,6 +30,23 @@ Jira Bot:
  > - Project: *Bots*
  > - Priority: *Medium*
  > - Status: *To Do*
+
+### search
+
+`search` takes in a search term and returns issues with matching summaries. For example,
+
+you:
+
+ > @**Jira Bot** search "XSS"
+
+Jira Bot:
+
+ > **Search results for *"XSS"*:**
+ >
+ > - ***BOTS-5:*** Stored XSS **[Published]**
+ > - ***BOTS-6:*** Reflected XSS **[Draft]**
+
+---
 
 ### create
 

--- a/zulip_bots/zulip_bots/bots/jira/fixtures/test_search.json
+++ b/zulip_bots/zulip_bots/bots/jira/fixtures/test_search.json
@@ -1,0 +1,47 @@
+{
+  "request": {
+    "api_url": "https://example.atlassian.net/rest/api/2/search?jql=summary ~ TEST&fields=key,summary,status",
+    "method": "GET",
+    "headers": {
+      "Authorization": "Basic ZXhhbXBsZUBleGFtcGxlLmNvbTpxd2VydHkhMTIz"
+    }
+  },
+  "response": {
+    "expand": "schema,names",
+    "startAt": 0,
+    "maxResults": 50,
+    "total": 2,
+    "issues": [
+      {
+        "id": "1",
+        "key": "TEST-1",
+        "fields": {
+          "creator": {"name": "admin"},
+          "description": "description",
+          "priority": {"name": "Medium"},
+          "project": {"name": "Tests"},
+          "issuetype": {"name": "Task"},
+          "status": {"name": "To Do"},
+          "summary": "summary test 1"
+        }
+      },
+      {
+        "id": "2",
+        "key": "TEST-2",
+        "fields": {
+          "creator": {"name": "admin"},
+          "description": "description",
+          "priority": {"name": "Medium"},
+          "project": {"name": "Tests"},
+          "issuetype": {"name": "Task"},
+          "status": {"name": "To Do"},
+          "summary": "summary test 2"
+        }
+      }
+    ]
+  },
+  "response-headers": {
+    "status": 200,
+    "content-type": "application/json; charset=utf-8"
+  }
+}

--- a/zulip_bots/zulip_bots/bots/jira/fixtures/test_search_scheme.json
+++ b/zulip_bots/zulip_bots/bots/jira/fixtures/test_search_scheme.json
@@ -1,0 +1,47 @@
+{
+  "request": {
+    "api_url": "http://example.atlassian.net/rest/api/2/search?jql=summary ~ TEST&fields=key,summary,status",
+    "method": "GET",
+    "headers": {
+      "Authorization": "Basic ZXhhbXBsZUBleGFtcGxlLmNvbTpxd2VydHkhMTIz"
+    }
+  },
+  "response": {
+    "expand": "schema,names",
+    "startAt": 0,
+    "maxResults": 50,
+    "total": 2,
+    "issues": [
+      {
+        "id": "1",
+        "key": "TEST-1",
+        "fields": {
+          "creator": {"name": "admin"},
+          "description": "description",
+          "priority": {"name": "Medium"},
+          "project": {"name": "Tests"},
+          "issuetype": {"name": "Task"},
+          "status": {"name": "To Do"},
+          "summary": "summary test 1"
+        }
+      },
+      {
+        "id": "2",
+        "key": "TEST-2",
+        "fields": {
+          "creator": {"name": "admin"},
+          "description": "description",
+          "priority": {"name": "Medium"},
+          "project": {"name": "Tests"},
+          "issuetype": {"name": "Task"},
+          "status": {"name": "To Do"},
+          "summary": "summary test 2"
+        }
+      }
+    ]
+  },
+  "response-headers": {
+    "status": 200,
+    "content-type": "application/json; charset=utf-8"
+  }
+}

--- a/zulip_bots/zulip_bots/bots/jira/jira.conf
+++ b/zulip_bots/zulip_bots/bots/jira/jira.conf
@@ -2,3 +2,4 @@
 username = <your Jira email address>
 password = <your Jira password>
 domain = <your Jira domain>
+# display_url = [optional] <your front facing Jira URL to use in links>

--- a/zulip_bots/zulip_bots/bots/jira/jira.py
+++ b/zulip_bots/zulip_bots/bots/jira/jira.py
@@ -28,6 +28,7 @@ EDIT_REGEX = re.compile(
     '$'
 )
 SEARCH_REGEX = re.compile('search "(?P<search_term>.+)"$')
+JQL_REGEX = re.compile('jql "(?P<jql_query>.+)"$')
 HELP_REGEX = re.compile('help$')
 
 HELP_RESPONSE = '''
@@ -67,6 +68,23 @@ Jira Bot:
  >
  > - ***BOTS-5:*** Stored XSS **[Published]**
  > - ***BOTS-6:*** Reflected XSS **[Draft]**
+
+---
+
+**jql**
+
+`jql` takes in a jql search string and returns matching issues. For example,
+
+you:
+
+ > @**Jira Bot** jql "issuetype = Engagement ORDER BY created DESC"
+
+Jira Bot:
+
+ > **Search results for *"issuetype = Engagement ORDER BY created DESC"*:**
+ >
+ > - ***BOTS-1:*** External Website Test **[In Progress]**
+ > - ***BOTS-3:*** Network Vulnerability Scan **[Draft]**
 
 ---
 
@@ -188,6 +206,7 @@ class JiraHandler:
         create_match = CREATE_REGEX.match(content)
         edit_match = EDIT_REGEX.match(content)
         search_match = SEARCH_REGEX.match(content)
+        jql_match = JQL_REGEX.match(content)
         help_match = HELP_REGEX.match(content)
 
         if get_match:
@@ -277,6 +296,10 @@ class JiraHandler:
             search_term = search_match.group('search_term')
             search_results = self.jql_search("summary ~ {}".format(search_term))
             response = '**Search results for "{}"**\n\n{}'.format(search_term, search_results)
+        elif jql_match:
+            jql_query = jql_match.group('jql_query')
+            search_results = self.jql_search(jql_query)
+            response = '**Search results for "{}"**\n\n{}'.format(jql_query, search_results)
         elif help_match:
             response = HELP_RESPONSE
         else:

--- a/zulip_bots/zulip_bots/bots/jira/jira.py
+++ b/zulip_bots/zulip_bots/bots/jira/jira.py
@@ -127,7 +127,12 @@ class JiraHandler:
             raise KeyError('No `domain` was specified')
 
         self.auth = make_jira_auth(username, password)
-        self.domain_with_protocol = 'https://' + domain
+
+        # Allow users to override the HTTP scheme
+        if re.match(r'^https?://', domain, re.IGNORECASE):
+            self.domain_with_protocol = domain
+        else:
+            self.domain_with_protocol = 'https://' + domain
 
     def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
         content = message.get('content')

--- a/zulip_bots/zulip_bots/bots/jira/jira.py
+++ b/zulip_bots/zulip_bots/bots/jira/jira.py
@@ -134,6 +134,11 @@ class JiraHandler:
         else:
             self.domain_with_protocol = 'https://' + domain
 
+        # Use the front facing URL in output
+        self.display_url = config.get('display_url')
+        if not self.display_url:
+            self.display_url = self.domain_with_protocol
+
     def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
         content = message.get('content')
         response = ''
@@ -153,7 +158,7 @@ class JiraHandler:
                 headers={'Authorization': self.auth},
             ).json()
 
-            url = self.domain_with_protocol + '/browse/' + key
+            url = self.display_url + '/browse/' + key
             errors = jira_response.get('errorMessages', [])
             fields = jira_response.get('fields', {})
 
@@ -196,7 +201,7 @@ class JiraHandler:
             jira_response_json = jira_response.json() if jira_response.text else {}
 
             key = jira_response_json.get('key', '')
-            url = self.domain_with_protocol + '/browse/' + key
+            url = self.display_url + '/browse/' + key
             errors = list(jira_response_json.get('errors', {}).values())
             if errors:
                 response = 'Oh no! Jira raised an error:\n > ' + ', '.join(errors)
@@ -220,7 +225,7 @@ class JiraHandler:
 
             jira_response_json = jira_response.json() if jira_response.text else {}
 
-            url = self.domain_with_protocol + '/browse/' + key
+            url = self.display_url + '/browse/' + key
             errors = list(jira_response_json.get('errors', {}).values())
             if errors:
                 response = 'Oh no! Jira raised an error:\n > ' + ', '.join(errors)

--- a/zulip_bots/zulip_bots/bots/jira/test_jira.py
+++ b/zulip_bots/zulip_bots/bots/jira/test_jira.py
@@ -106,7 +106,7 @@ Jira Bot:
 
     def _test_invalid_config(self, invalid_config, error_message) -> None:
         with self.mock_config_info(invalid_config), \
-                self.assertRaisesRegexp(KeyError, error_message):
+                self.assertRaisesRegex(KeyError, error_message):
             bot, bot_handler = self._get_handlers()
 
     def test_config_without_username(self) -> None:

--- a/zulip_bots/zulip_bots/bots/jira/test_jira.py
+++ b/zulip_bots/zulip_bots/bots/jira/test_jira.py
@@ -80,6 +80,23 @@ Jira Bot:
 
 ---
 
+**jql**
+
+`jql` takes in a jql search string and returns matching issues. For example,
+
+you:
+
+ > @**Jira Bot** jql "issuetype = Engagement ORDER BY created DESC"
+
+Jira Bot:
+
+ > **Search results for *"issuetype = Engagement ORDER BY created DESC"*:**
+ >
+ > - ***BOTS-1:*** External Website Test **[In Progress]**
+ > - ***BOTS-3:*** Network Vulnerability Scan **[Draft]**
+
+---
+
 **create**
 
 `create` creates an issue using its
@@ -137,6 +154,7 @@ Jira Bot:
     MOCK_SEARCH_RESPONSE = '**Search results for "TEST"**\n\n*Found 2 results*\n\n\n - TEST-1: [summary test 1](https://example.atlassian.net/browse/TEST-1) **[To Do]**\n - TEST-2: [summary test 2](https://example.atlassian.net/browse/TEST-2) **[To Do]**'
     MOCK_SEARCH_RESPONSE_URL = '**Search results for "TEST"**\n\n*Found 2 results*\n\n\n - TEST-1: [summary test 1](http://test.com/browse/TEST-1) **[To Do]**\n - TEST-2: [summary test 2](http://test.com/browse/TEST-2) **[To Do]**'
     MOCK_SEARCH_RESPONSE_SCHEME = '**Search results for "TEST"**\n\n*Found 2 results*\n\n\n - TEST-1: [summary test 1](http://example.atlassian.net/browse/TEST-1) **[To Do]**\n - TEST-2: [summary test 2](http://example.atlassian.net/browse/TEST-2) **[To Do]**'
+    MOCK_JQL_RESPONSE = '**Search results for "summary ~ TEST"**\n\n*Found 2 results*\n\n\n - TEST-1: [summary test 1](https://example.atlassian.net/browse/TEST-1) **[To Do]**\n - TEST-2: [summary test 2](https://example.atlassian.net/browse/TEST-2) **[To Do]**'
 
     def _test_invalid_config(self, invalid_config, error_message) -> None:
         with self.mock_config_info(invalid_config), \
@@ -211,6 +229,11 @@ Jira Bot:
         with self.mock_config_info(self.MOCK_CONFIG_INFO), \
                 self.mock_http_conversation('test_search'):
             self.verify_reply('search "TEST"', self.MOCK_SEARCH_RESPONSE)
+
+    def test_jql(self) -> None:
+        with self.mock_config_info(self.MOCK_CONFIG_INFO), \
+                self.mock_http_conversation('test_search'):
+            self.verify_reply('jql "summary ~ TEST"', self.MOCK_JQL_RESPONSE)
 
     def test_search_url(self) -> None:
         with self.mock_config_info(self.MOCK_DISPLAY_CONFIG_INFO), \

--- a/zulip_bots/zulip_bots/bots/jira/test_jira.py
+++ b/zulip_bots/zulip_bots/bots/jira/test_jira.py
@@ -9,6 +9,19 @@ class TestJiraBot(BotTestCase, DefaultTests):
         'domain': 'example.atlassian.net'
     }
 
+    MOCK_SCHEME_CONFIG_INFO = {
+        'username': 'example@example.com',
+        'password': 'qwerty!123',
+        'domain': 'http://example.atlassian.net'
+    }
+
+    MOCK_DISPLAY_CONFIG_INFO = {
+        'username': 'example@example.com',
+        'password': 'qwerty!123',
+        'domain': 'example.atlassian.net',
+        'display_url': 'http://test.com'
+    }
+
     MOCK_GET_RESPONSE = '''\
 **Issue *[TEST-13](https://example.atlassian.net/browse/TEST-13)*: summary**
 
@@ -47,6 +60,23 @@ Jira Bot:
  > - Project: *Bots*
  > - Priority: *Medium*
  > - Status: *To Do*
+
+---
+
+**search**
+
+`search` takes in a search term and returns issues with matching summaries. For example,
+
+you:
+
+ > @**Jira Bot** search "XSS"
+
+Jira Bot:
+
+ > **Search results for *"XSS"*:**
+ >
+ > - ***BOTS-5:*** Stored XSS **[Published]**
+ > - ***BOTS-6:*** Reflected XSS **[Draft]**
 
 ---
 
@@ -103,6 +133,10 @@ Jira Bot:
 
  > Issue *BOTS-16* was edited! https://example.atlassian.net/browse/BOTS-16
 '''
+
+    MOCK_SEARCH_RESPONSE = '**Search results for "TEST"**\n\n*Found 2 results*\n\n\n - TEST-1: [summary test 1](https://example.atlassian.net/browse/TEST-1) **[To Do]**\n - TEST-2: [summary test 2](https://example.atlassian.net/browse/TEST-2) **[To Do]**'
+    MOCK_SEARCH_RESPONSE_URL = '**Search results for "TEST"**\n\n*Found 2 results*\n\n\n - TEST-1: [summary test 1](http://test.com/browse/TEST-1) **[To Do]**\n - TEST-2: [summary test 2](http://test.com/browse/TEST-2) **[To Do]**'
+    MOCK_SEARCH_RESPONSE_SCHEME = '**Search results for "TEST"**\n\n*Found 2 results*\n\n\n - TEST-1: [summary test 1](http://example.atlassian.net/browse/TEST-1) **[To Do]**\n - TEST-2: [summary test 2](http://example.atlassian.net/browse/TEST-2) **[To Do]**'
 
     def _test_invalid_config(self, invalid_config, error_message) -> None:
         with self.mock_config_info(invalid_config), \
@@ -172,6 +206,21 @@ Jira Bot:
                               'by assigning to "testuser" to use priority "Low" by labeling "issues, testing" '
                               'by making due "2018-06-11"',
                               'Oh no! Jira raised an error:\n > error1')
+
+    def test_search(self) -> None:
+        with self.mock_config_info(self.MOCK_CONFIG_INFO), \
+                self.mock_http_conversation('test_search'):
+            self.verify_reply('search "TEST"', self.MOCK_SEARCH_RESPONSE)
+
+    def test_search_url(self) -> None:
+        with self.mock_config_info(self.MOCK_DISPLAY_CONFIG_INFO), \
+                self.mock_http_conversation('test_search'):
+            self.verify_reply('search "TEST"', self.MOCK_SEARCH_RESPONSE_URL)
+
+    def test_search_scheme(self) -> None:
+        with self.mock_config_info(self.MOCK_SCHEME_CONFIG_INFO), \
+                self.mock_http_conversation('test_search_scheme'):
+            self.verify_reply('search "TEST"', self.MOCK_SEARCH_RESPONSE_SCHEME)
 
     def test_help(self) -> None:
         with self.mock_config_info(self.MOCK_CONFIG_INFO):


### PR DESCRIPTION
This PR adds functionality for searching issue summaries with `search` and full blown JQL search with `jql`.

It also supports the user defining their own HTTP scheme in the `domain`, this is useful for circumstances where Jira is served behind an authenticating proxy. This allows you to connect to a secondary listener that might not be HTTPS. An optional configuration parameter was also added `display_url` so the URL for the output links can also be controlled.

E.g. Users access Jira through a proxy at `https://jira.mydomain.com`. The actual Jira host listens on `http://jira1.mydomain.com:8081`. You can now configure this using
```
[jira]
username = test
password = test_password
domain = http://jira1.mydomain.com:8081
display_url = https://jira.mydomain.com
```