### PR TITLE
Remove six/typing dependencies & add project_urls

### DIFF
--- a/tools/.coveragerc
+++ b/tools/.coveragerc
@@ -9,9 +9,6 @@ exclude_lines =
     raise NotImplementedError()
     # Don't require coverage for test suite AssertionError -- they're usually for clarity
     raise AssertionError
-    # Don't require coverage for Python 2/3 variations; it's impossible to cover on both
-    if six.PY3:
-    if six.PY2:
     # Don't require coverage for __unicode__ statements just used for printing
     def __unicode__[(]self[)]:
 

--- a/zulip/README.md
+++ b/zulip/README.md
@@ -5,8 +5,6 @@ following dependencies:
 
 * **Python (version >= 3.5)**
 * requests (version >= 0.12.1)
-* six
-* typing (version >= 3.5.2.2)
 
 **Note**: If you'd like to use the Zulip bindings with Python 2, we
 recommend installing version 0.6.4.

--- a/zulip/setup.py
+++ b/zulip/setup.py
@@ -47,6 +47,10 @@ package_info = dict(
     ],
     python_requires='>=3.5',
     url='https://www.zulip.org/',
+    project_urls={
+        "Source": "https://github.com/zulip/python-zulip-api/",
+        "Documentation": "https://zulipchat.com/api",
+    },
     data_files=list(recur_expand('share/zulip', 'integrations')),
     include_package_data=True,
     entry_points={

--- a/zulip/setup.py
+++ b/zulip/setup.py
@@ -61,8 +61,6 @@ package_info = dict(
 
 setuptools_info = dict(
     install_requires=['requests[security]>=0.12.1',
-                      'six',
-                      'typing>=3.5.2.2;python_version<"3.5"',
                       'matrix_client',
                       'distro',
                       ],

--- a/zulip_bots/setup.py
+++ b/zulip_bots/setup.py
@@ -45,6 +45,10 @@ package_info = dict(
     ],
     python_requires='>=3.5',
     url='https://www.zulip.org/',
+    project_urls={
+        "Source": "https://github.com/zulip/python-zulip-api/",
+        "Documentation": "https://zulipchat.com/api",
+    },
     entry_points={
         'console_scripts': [
             'zulip-run-bot=zulip_bots.run:main',

--- a/zulip_botserver/setup.py
+++ b/zulip_botserver/setup.py
@@ -31,6 +31,10 @@ package_info = dict(
     ],
     python_requires='>=3.5',
     url='https://www.zulip.org/',
+    project_urls={
+        "Source": "https://github.com/zulip/python-zulip-api/",
+        "Documentation": "https://zulipchat.com/api",
+    },
     entry_points={
         'console_scripts': [
             'zulip-botserver=zulip_botserver.server:main',


### PR DESCRIPTION
Even though the this repo is now python3.5+, we have retained a `six` and `typing` dependency, which we can now remove.

Also, the URL for each package currently points to zulip.org -> zulipchat.com. The second commit should add links in the PyPI sidebar to the git repo and the zulipchat.com/api page, which otherwise are not particularly obvious.