### PR TITLE
zephyr: Use exponential backoffs in retry loops.

### DIFF
--- a/zulip/integrations/zephyr/zephyr_mirror_backend.py
+++ b/zulip/integrations/zephyr/zephyr_mirror_backend.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from typing import Any, Dict, IO, List, Optional, Set, Text, Tuple, cast
+from typing import Any, Dict, IO, List, NoReturn, Optional, Set, Text, Tuple, cast
 from types import FrameType
 
 import sys
@@ -232,7 +232,7 @@ def maybe_restart_mirroring_script() -> None:
                 backoff.fail()
         raise Exception("Failed to reload too many times, aborting!")
 
-def process_loop(log: Optional[IO[Any]]) -> None:
+def process_loop(log: Optional[IO[Any]]) -> NoReturn:
     restart_check_count = 0
     last_check_time = time.time()
     recieve_backoff = RandomExponentialBackoff()
@@ -767,7 +767,7 @@ def maybe_forward_to_zephyr(message: Dict[str, Any]) -> None:
             # whole process
             logger.exception("Error forwarding message:")
 
-def zulip_to_zephyr(options: int) -> None:
+def zulip_to_zephyr(options: int) -> NoReturn:
     # Sync messages from zulip to zephyr
     logger.info("Starting syncing messages.")
     backoff = RandomExponentialBackoff(timeout_success_equivalent=120)
@@ -1146,7 +1146,6 @@ or specify the --api-key-file option.""" % (options.api_key_file,))))
             # Run the zulip => zephyr mirror in the child
             configure_logger(logger, "zulip=>zephyr")
             zulip_to_zephyr(options)
-            sys.exit(0)
     else:
         child_pid = None
     CURRENT_STATE = States.ZephyrToZulip

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -33,7 +33,27 @@ requests_json_is_function = callable(requests.Response.json)
 API_VERSTRING = "v1/"
 
 class CountingBackoff:
-    def __init__(self, maximum_retries: int = 10, timeout_success_equivalent: Optional[float] = None, delay_cap: float = 90.0) -> None:
+    def __init__(
+        self,
+        maximum_retries: int = 10,
+        timeout_success_equivalent: Optional[float] = None,
+        delay_cap: float = 90.0,
+    ) -> None:
+        """Sets up a retry-backoff object.  Example usage:
+        backoff = zulip.CountingBackoff()
+        while backoff.keep_going():
+            try:
+                something()
+                backoff.succeed()
+            except Exception:
+                backoff.fail()
+
+        timeout_success_equivalent is used in cases where 'success' is
+        never possible to determine automatically; it sets the
+        threshold in seconds before the next keep_going/fail, above
+        which the last run is treated like it was a success.
+
+        """
         self.number_of_retries = 0
         self.maximum_retries = maximum_retries
         self.timeout_success_equivalent = timeout_success_equivalent


### PR DESCRIPTION
This reduces the number of retries that might spam APIs.

There is some complexity here which is left un-managed -- for
instance, maybe_restart_mirroring_script does a number of restart
attempts, and then fails, but will be retried every 15s by the
surrounding `process_loop`.  Previously, it would merely have looped
forever inside maybe_restart_mirroring_script.

Three loops are intentionally left as infinite `while True` loops,
that merely cap their backoff at the default 90s.  Their callers do
not expect, or have any way to handle more gracefully, a failure of
the expected-infinite-loop in `process_loop` or `zulip_to_zephyr`.
They maintain their previous behavior of retrying forever, albeit more
slowly.