### PR TITLE
zulip: Add hash_util_decode() to decode server encoded URL excerpts

### DIFF
--- a/zulip/tests/test_hash_util_decode.py
+++ b/zulip/tests/test_hash_util_decode.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import unittest
+import zulip
+
+from unittest import TestCase
+
+class TestHashUtilDecode(TestCase):
+    def test_hash_util_decode(self) -> None:
+        tests = [
+            ('topic', 'topic'),
+            ('.2Edot', '.dot'),
+            ('.23stream.20name', '#stream name'),
+            ('(no.20topic)', '(no topic)'),
+            ('.3Cstrong.3Ebold.3C.2Fstrong.3E', '<strong>bold</strong>'),
+            ('.3Asome_emoji.3A', ':some_emoji:'),
+        ]
+        for encoded_string, decoded_string in tests:
+            with self.subTest(encoded_string=encoded_string):
+                self.assertEqual(zulip.hash_util_decode(encoded_string), decoded_string)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -1544,3 +1544,15 @@ class ZulipStream:
 
     def flush(self) -> None:
         pass
+
+def hash_util_decode(string: str) -> str:
+    """
+    Returns a decoded string given a hash_util_encode() [present in zulip/zulip's zerver/lib/url_encoding.py] encoded string.
+
+    Example usage:
+    >>> zulip.hash_util_decode('test.20here')
+    'test here'
+    """
+    # Acknowledge custom string replacements in zulip/zulip's zerver/lib/url_encoding.py before unquoting.
+    # NOTE: urllib.parse.unquote already does .replace('%2E', '.').
+    return urllib.parse.unquote(string.replace('.', '%'))


### PR DESCRIPTION
This adds `hash_util_decode()` to decode a `hash_util_encode()` [present in [zulip/zulip's zerver/lib/url_encoding.py](https://github.com/zulip/zulip/blob/master/zerver/lib/url_encoding.py)] encoded string.

The intent is to facilitate code sharing among various python clients (primarily, Zulip Terminal).

The string replacement before the `unquote` is to recoup for the custom string replacements in [zulip/zulip's zerver/lib/url_encoding.py](https://github.com/zulip/zulip/blob/master/zerver/lib/url_encoding.py).

Conversation link: https://chat.zulip.org/#narrow/stream/127-integrations/topic/Decode.20server.20URLs/near/977374