### PR TITLE
provision: Fix source command on Windows

### DIFF
--- a/tools/provision
+++ b/tools/provision
@@ -116,6 +116,9 @@ the Python version this command is executed with."""
                                     venv_dir,
                                     venv_exec_dir,
                                     'activate')
+    # We make the path look like a Unix path, because most Windows users
+    # are likely to be running in a bash shell.
+    activate_command = activate_command.replace(os.sep, '/')
     print('\nRun the following to enter into the virtualenv:\n')
     print(bold + '  source ' + activate_command + end_format + "\n")
 


### PR DESCRIPTION
Currently, the provision script gives us something like this on Windows:
```bash
Run the following to enter into the virtualenv:

  source C:\Users\qedk\python-zulip-api\zulip-api-py3-venv\Scripts\activate
```
However, `bash` does not work with  backslashes and will give us an error saying `No such file or directory`.
This commit addresses that so we get the correct command with the forward slashes:
```bash
Run the following to enter into the virtualenv:

  source C:/Users/qedk/python-zulip-api/zulip-api-py3-venv/Scripts/activate
```