### PR TITLE
Changes to make rss bot working with zulip 3.3 and Debian 10.7 :

### DIFF
--- a/zulip/integrations/rss/rss-bot
+++ b/zulip/integrations/rss/rss-bot
@@ -111,6 +111,7 @@ def log_error_and_exit(error: str) -> None:
 
 class MLStripper(HTMLParser):
     def __init__(self) -> None:
+        super().__init__()
         self.reset()
         self.fed = []  # type: List[str]
 
@@ -128,7 +129,7 @@ def strip_tags(html: str) -> str:
 def compute_entry_hash(entry: Dict[str, Any]) -> str:
     entry_time = entry.get("published", entry.get("updated"))
     entry_id = entry.get("id", entry.get("link"))
-    return hashlib.md5(entry_id + str(entry_time)).hexdigest()
+    return hashlib.md5((entry_id + str(entry_time)).encode()).hexdigest()
 
 def unwrap_text(body: str) -> str:
     # Replace \n by space if it is preceded and followed by a non-\n.


### PR DESCRIPTION
- Add init method
- Change return hashlib.md5 synthax

Signed-off-by: Manu LN <manu+github@lacavernedemanu.fr>

Before changes, while trying to get rss infos in RSS stream the script output was 

```
Traceback (most recent call last):
  File ".local/share/zulip/integrations/rss/rss-bot", line 190, in <module>
    entry_hash = compute_entry_hash(entry)  # type: str
  File ".local/share/zulip/integrations/rss/rss-bot", line 131, in compute_entry_hash
    return hashlib.md5(entry_id + str(entry_time)).hexdigest()
TypeError: Unicode-objects must be encoded before hashing
```