### PR TITLE
Fix tests failing on Windows.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pytest
 -e ./zulip
 -e ./zulip_bots
 -e ./zulip_botserver
--e git+https://github.com/zulip/zulint@639c0d34c23ac559ef0f7b9510cf95f73f6d0eb9#egg=zulint==1.0.0
-mypy==0.770
+-e git+https://github.com/zulip/zulint@14e3974001bf8442a6a3486125865660f1f2eb68#egg=zulint==1.0.0
+mypy==0.790

--- a/tools/lint
+++ b/tools/lint
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 
 import argparse
+import sys
 
 from zulint.command import add_default_linter_arguments, LinterConfig
 
@@ -21,7 +22,7 @@ def run() -> None:
     by_lang = linter_config.list_files(file_types=['py', 'sh', 'json', 'md', 'txt'],
                                        exclude=EXCLUDED_FILES)
 
-    linter_config.external_linter('mypy', ['tools/run-mypy'], ['py'], pass_targets=False,
+    linter_config.external_linter('mypy', [sys.executable, 'tools/run-mypy'], ['py'], pass_targets=False,
                                   description="Static type checker for Python (config: mypy.ini)")
     linter_config.external_linter('flake8', ['flake8'], ['py'],
                                   description="Standard Python linter (config: .flake8)")

--- a/zulip_bots/zulip_bots/bots/file_uploader/test_file_uploader.py
+++ b/zulip_bots/zulip_bots/bots/file_uploader/test_file_uploader.py
@@ -20,7 +20,7 @@ class TestFileUploaderBot(BotTestCase, DefaultTests):
         server_reply = dict(result='', msg='error')
         with patch('zulip_bots.test_lib.StubBotHandler.upload_file_from_path',
                    return_value=server_reply):
-            self.verify_reply('file.txt', 'Failed to upload `/file.txt` file: error')
+            self.verify_reply('file.txt', 'Failed to upload `{}` file: error'.format(Path('file.txt').resolve()))
 
     @patch('pathlib.Path.resolve', return_value=Path('/file.txt'))
     @patch('pathlib.Path.is_file', return_value=True)

--- a/zulip_bots/zulip_bots/bots/yoda/yoda.py
+++ b/zulip_bots/zulip_bots/bots/yoda/yoda.py
@@ -97,7 +97,7 @@ class YodaSpeakHandler:
                 if len(reply_message) == 0:
                     reply_message = 'Invalid input, please check the sentence you have entered.'
 
-            except ssl.SSLError or TypeError:
+            except (ssl.SSLError, TypeError):
                 reply_message = 'The service is temporarily unavailable, please try again.'
                 logging.error(reply_message)
 

--- a/zulip_bots/zulip_bots/finder.py
+++ b/zulip_bots/zulip_bots/finder.py
@@ -1,7 +1,7 @@
 import sys
 import os
-from os.path import basename, splitext
 from typing import Any, Optional, Text, Tuple
+from pathlib import Path
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -30,14 +30,14 @@ def import_module_by_name(name: Text) -> Any:
     except ImportError:
         return None
 
-def resolve_bot_path(name: Text) -> Optional[Tuple[Text, Text]]:
+def resolve_bot_path(name: Text) -> Optional[Tuple[Path, Text]]:
     if os.path.isfile(name):
-        bot_path = os.path.abspath(name)
-        bot_name = splitext(basename(bot_path))[0]
+        bot_path = Path(name)
+        bot_name = Path(bot_path).stem
         return (bot_path, bot_name)
     else:
         bot_name = name
-        bot_path = os.path.abspath(os.path.join(current_dir, 'bots', bot_name, bot_name + '.py'))
+        bot_path = Path(current_dir, 'bots', bot_name, bot_name + '.py')
         if os.path.isfile(bot_path):
             return (bot_path, bot_name)
 

--- a/zulip_bots/zulip_bots/run.py
+++ b/zulip_bots/zulip_bots/run.py
@@ -110,7 +110,7 @@ def main() -> None:
             provision_bot(os.path.dirname(bot_path), args.force)
 
         try:
-            lib_module = finder.import_module_from_source(bot_path, bot_name)
+            lib_module = finder.import_module_from_source(bot_path.as_posix(), bot_name)
         except ImportError:
             req_path = os.path.join(os.path.dirname(bot_path), "requirements.txt")
             with open(req_path) as fp:

--- a/zulip_bots/zulip_bots/tests/test_finder.py
+++ b/zulip_bots/zulip_bots/tests/test_finder.py
@@ -1,5 +1,5 @@
-import os
 from unittest import TestCase
+from pathlib import Path
 
 from zulip_bots import finder
 
@@ -7,8 +7,8 @@ from zulip_bots import finder
 class FinderTestCase(TestCase):
 
     def test_resolve_bot_path(self) -> None:
-        current_directory = os.path.dirname(os.path.abspath(__file__))
-        expected_bot_path = os.path.abspath(current_directory + '/../bots/helloworld/helloworld.py')
+        current_directory = Path(__file__).parents[1].as_posix()
+        expected_bot_path = Path(current_directory + '/bots/helloworld/helloworld.py')
         expected_bot_name = 'helloworld'
         expected_bot_path_and_name = (expected_bot_path, expected_bot_name)
         actual_bot_path_and_name = finder.resolve_bot_path('helloworld')

--- a/zulip_bots/zulip_bots/tests/test_run.py
+++ b/zulip_bots/zulip_bots/tests/test_run.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from pathlib import Path
 import os
 import sys
 import zulip_bots.run
@@ -43,17 +44,17 @@ class TestDefaultArguments(TestCase):
 
     def test_adding_bot_parent_dir_to_sys_path_when_bot_name_specified(self) -> None:
         bot_name = 'helloworld'  # existing bot's name
-        expected_bot_dir_path = os.path.join(
+        expected_bot_dir_path = Path(
             os.path.dirname(zulip_bots.run.__file__),
             'bots',
             bot_name
-        )
+        ).as_posix()
         self._test_adding_bot_parent_dir_to_sys_path(bot_qualifier=bot_name, bot_dir_path=expected_bot_dir_path)
 
     @patch('os.path.isfile', return_value=True)
     def test_adding_bot_parent_dir_to_sys_path_when_bot_path_specified(self, mock_os_path_isfile: mock.Mock) -> None:
         bot_path = '/path/to/bot'
-        expected_bot_dir_path = '/path/to'
+        expected_bot_dir_path = Path('/path/to').as_posix()
         self._test_adding_bot_parent_dir_to_sys_path(bot_qualifier=bot_path, bot_dir_path=expected_bot_dir_path)
 
     def _test_adding_bot_parent_dir_to_sys_path(self, bot_qualifier: str, bot_dir_path: str) -> None:
@@ -63,7 +64,8 @@ class TestDefaultArguments(TestCase):
                     with patch('zulip_bots.run.exit_gracefully_if_zulip_config_is_missing'):
                         zulip_bots.run.main()
 
-        self.assertIn(bot_dir_path, sys.path)
+        sys_path = [Path(path).as_posix() for path in sys.path]
+        self.assertIn(bot_dir_path, sys_path)
 
     @patch('os.path.isfile', return_value=False)
     def test_run_bot_by_module_name(self, mock_os_path_isfile: mock.Mock) -> None:

--- a/zulip_botserver/tests/test_server.py
+++ b/zulip_botserver/tests/test_server.py
@@ -7,6 +7,7 @@ import json
 from collections import OrderedDict
 from importlib import import_module
 from types import ModuleType
+from pathlib import Path
 
 from zulip_botserver import server
 from zulip_botserver.input_parameters import parse_args
@@ -213,13 +214,13 @@ class BotServerTests(BotServerTestCase):
         # restructure zulip_bots, this test would fail and we would also update Botserver
         # at the same time.
         helloworld = import_module('zulip_bots.bots.{bot}.{bot}'.format(bot='helloworld'))
-        root_dir = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../'))
+        root_dir = Path(__file__).parents[2].as_posix()
         # load valid module name
         module = server.load_lib_modules(['helloworld'])['helloworld']
         assert module == helloworld
 
         # load valid file path
-        path = os.path.join(root_dir, 'zulip_bots/zulip_bots/bots/{bot}/{bot}.py'.format(bot='helloworld'))
+        path = Path(root_dir, 'zulip_bots/zulip_bots/bots/{bot}/{bot}.py'.format(bot='helloworld')).as_posix()
         module = server.load_lib_modules([path])[path]
         assert module.__name__ == 'custom_bot_module'
         assert module.__file__ == path
@@ -235,7 +236,7 @@ class BotServerTests(BotServerTestCase):
         with self.assertRaisesRegexp(SystemExit,  # type: ignore
                                      'Error: Bot "{}/zulip_bots/zulip_bots/bots/helloworld.py" doesn\'t exist. '
                                      'Please make sure you have set up the botserverrc file correctly.'.format(root_dir)):
-            path = os.path.join(root_dir, 'zulip_bots/zulip_bots/bots/{bot}.py'.format(bot='helloworld'))
+            path = Path(root_dir, 'zulip_bots/zulip_bots/bots/{bot}.py'.format(bot='helloworld')).as_posix()
             module = server.load_lib_modules([path])[path]
 
 if __name__ == '__main__':


### PR DESCRIPTION
Tests were failing on Windows since paths are case-insensitive on it.
This uses pathlib library to compare paths on all platforms.

Fixes #651