### PR TITLE
zulip-bots: Add `BotHandler` Protocol.

### DIFF
--- a/zulip_bots/setup.py
+++ b/zulip_bots/setup.py
@@ -65,6 +65,7 @@ setuptools_info = dict(
         'html2text',
         'lxml',
         'BeautifulSoup4',
+        'typing_extensions',
     ],
 )
 

--- a/zulip_bots/zulip_bots/bots/baremetrics/baremetrics.py
+++ b/zulip_bots/zulip_bots/bots/baremetrics/baremetrics.py
@@ -1,10 +1,11 @@
 # See readme.md for instructions on running this code.
 
 from typing import Any, List, Dict
+from zulip_bots.lib import BotHandler
 import requests
 
 class BaremetricsHandler:
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('baremetrics')
         self.api_key = self.config_info['api_key']
 
@@ -27,7 +28,7 @@ class BaremetricsHandler:
 
         self.check_api_key(bot_handler)
 
-    def check_api_key(self, bot_handler: Any) -> None:
+    def check_api_key(self, bot_handler: BotHandler) -> None:
         url = "https://api.baremetrics.com/v1/account"
         test_query_response = requests.get(url, headers=self.auth_header)
         test_query_data = test_query_response.json()
@@ -46,7 +47,7 @@ class BaremetricsHandler:
         Version 1.0
         '''
 
-    def handle_message(self, message: Dict[str, Any], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, Any], bot_handler: BotHandler) -> None:
         content = message['content'].strip().split()
 
         if content == []:

--- a/zulip_bots/zulip_bots/bots/beeminder/beeminder.py
+++ b/zulip_bots/zulip_bots/bots/beeminder/beeminder.py
@@ -1,6 +1,7 @@
 import requests
 import logging
-from typing import Any, Dict
+from typing import Dict
+from zulip_bots.lib import BotHandler
 from requests.exceptions import ConnectionError
 
 help_message = '''
@@ -79,7 +80,7 @@ class BeeminderHandler:
     towards their beeminder goals via zulip
     '''
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('beeminder')
         # Check for valid auth_token
         auth_token = self.config_info['auth_token']
@@ -93,7 +94,7 @@ class BeeminderHandler:
     def usage(self) -> str:
         return "This plugin allows users to add datapoints towards their Beeminder goals"
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         response = get_beeminder_response(message['content'], self.config_info)
         bot_handler.send_reply(message, response)
 

--- a/zulip_bots/zulip_bots/bots/chessbot/chessbot.py
+++ b/zulip_bots/zulip_bots/bots/chessbot/chessbot.py
@@ -3,6 +3,7 @@ import chess.uci
 import re
 import copy
 from typing import Any, Optional, Dict
+from zulip_bots.lib import BotHandler
 
 START_REGEX = re.compile('start with other user$')
 START_COMPUTER_REGEX = re.compile(
@@ -22,7 +23,7 @@ class ChessHandler:
             'Stockfish program on this computer.'
         )
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('chess')
 
         try:
@@ -38,7 +39,7 @@ class ChessHandler:
     def handle_message(
         self,
         message: Dict[str, str],
-        bot_handler: Any
+        bot_handler: BotHandler
     ) -> None:
         content = message['content']
 
@@ -93,7 +94,7 @@ class ChessHandler:
                 last_fen
             )
 
-    def start(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def start(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         """Starts a game with another user, with the current user as white.
         Replies to the bot handler.
 
@@ -115,7 +116,7 @@ class ChessHandler:
     def start_computer(
         self,
         message: Dict[str, str],
-        bot_handler: Any,
+        bot_handler: BotHandler,
         is_white_user: bool
     ) -> None:
         """Starts a game with the computer. Replies to the bot handler.
@@ -151,7 +152,7 @@ class ChessHandler:
     def validate_board(
         self,
         message: Dict[str, str],
-        bot_handler: Any,
+        bot_handler: BotHandler,
         fen: str
     ) -> Optional[chess.Board]:
         """Validates a board based on its FEN string. Replies to the bot
@@ -179,7 +180,7 @@ class ChessHandler:
     def validate_move(
         self,
         message: Dict[str, str],
-        bot_handler: Any,
+        bot_handler: BotHandler,
         last_board: chess.Board,
         move_san: str,
         is_computer: object
@@ -223,7 +224,7 @@ class ChessHandler:
     def check_game_over(
         self,
         message: Dict[str, str],
-        bot_handler: Any,
+        bot_handler: BotHandler,
         new_board: chess.Board
     ) -> bool:
         """Checks if a game is over due to
@@ -280,7 +281,7 @@ class ChessHandler:
     def move(
         self,
         message: Dict[str, str],
-        bot_handler: Any,
+        bot_handler: BotHandler,
         last_fen: str,
         move_san: str
     ) -> None:
@@ -325,7 +326,7 @@ class ChessHandler:
     def move_computer(
         self,
         message: Dict[str, str],
-        bot_handler: Any,
+        bot_handler: BotHandler,
         last_fen: str,
         move_san: str
     ) -> None:
@@ -396,7 +397,7 @@ class ChessHandler:
     def move_computer_first(
         self,
         message: Dict[str, str],
-        bot_handler: Any,
+        bot_handler: BotHandler,
         last_fen: str
     ) -> None:
         """Preforms a move for the computer without having the user go first in
@@ -447,7 +448,7 @@ class ChessHandler:
     def resign(
         self,
         message: Dict[str, str],
-        bot_handler: Any,
+        bot_handler: BotHandler,
         last_fen: str
     ) -> None:
         """Resigns the game for the current player.

--- a/zulip_bots/zulip_bots/bots/converter/converter.py
+++ b/zulip_bots/zulip_bots/bots/converter/converter.py
@@ -6,6 +6,7 @@ from math import log10, floor
 from zulip_bots.bots.converter import utils
 
 from typing import Any, Dict, List
+from zulip_bots.lib import BotHandler
 
 def is_float(value: Any) -> bool:
     try:
@@ -44,11 +45,11 @@ class ConverterHandler:
                all supported units.
                '''
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         bot_response = get_bot_converter_response(message, bot_handler)
         bot_handler.send_reply(message, bot_response)
 
-def get_bot_converter_response(message: Dict[str, str], bot_handler: Any) -> str:
+def get_bot_converter_response(message: Dict[str, str], bot_handler: BotHandler) -> str:
     content = message['content']
 
     words = content.lower().split()

--- a/zulip_bots/zulip_bots/bots/define/define.py
+++ b/zulip_bots/zulip_bots/bots/define/define.py
@@ -4,7 +4,8 @@ import requests
 import html2text
 import string
 
-from typing import Any, Dict
+from typing import Dict
+from zulip_bots.lib import BotHandler
 
 class DefineHandler:
     '''
@@ -24,7 +25,7 @@ class DefineHandler:
             messages with @mention-bot.
             '''
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         original_content = message['content'].strip()
         bot_response = self.get_bot_define_response(original_content)
 

--- a/zulip_bots/zulip_bots/bots/dialogflow/dialogflow.py
+++ b/zulip_bots/zulip_bots/bots/dialogflow/dialogflow.py
@@ -4,7 +4,8 @@ import json
 
 import apiai
 
-from typing import Any, Dict
+from typing import Dict
+from zulip_bots.lib import BotHandler
 
 help_message = '''DialogFlow bot
 This bot will interact with dialogflow bots.
@@ -40,7 +41,7 @@ class DialogFlowHandler:
     DialogFlow bots to zulip
     '''
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('dialogflow')
 
     def usage(self) -> str:
@@ -49,7 +50,7 @@ class DialogFlowHandler:
             DialogFlow bots to zulip
             '''
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         result = get_bot_result(message['content'], self.config_info, message['sender_id'])
         bot_handler.send_reply(message, result)
 

--- a/zulip_bots/zulip_bots/bots/dropbox_share/dropbox_share.py
+++ b/zulip_bots/zulip_bots/bots/dropbox_share/dropbox_share.py
@@ -1,5 +1,6 @@
 from dropbox import Dropbox
 from typing import Any, Dict, List, Tuple
+from zulip_bots.lib import BotHandler
 import re
 
 URL = "[{name}](https://www.dropbox.com/home{path})"
@@ -10,7 +11,7 @@ class DropboxHandler:
     between zulip and your dropbox account.
     '''
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('dropbox_share')
         self.ACCESS_TOKEN = self.config_info.get('access_token')
         self.client = Dropbox(self.ACCESS_TOKEN)
@@ -18,7 +19,7 @@ class DropboxHandler:
     def usage(self) -> str:
         return get_help()
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         command = message['content']
         if command == "":
             command = "help"

--- a/zulip_bots/zulip_bots/bots/encrypt/encrypt.py
+++ b/zulip_bots/zulip_bots/bots/encrypt/encrypt.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict
+from typing import Dict
+from zulip_bots.lib import BotHandler
 
 def encrypt(text: str) -> str:
     # This is where the actual ROT13 is applied
@@ -30,7 +31,7 @@ class EncryptHandler:
             Feeding encrypted messages into the bot decrypts them.
             '''
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         bot_response = self.get_bot_encrypt_response(message)
         bot_handler.send_reply(message, bot_response)
 

--- a/zulip_bots/zulip_bots/bots/file_uploader/file_uploader.py
+++ b/zulip_bots/zulip_bots/bots/file_uploader/file_uploader.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict
+from typing import Dict
+from zulip_bots.lib import BotHandler
 
 import os
 from pathlib import Path
@@ -11,7 +12,7 @@ class FileUploaderHandler:
             '\n- @uploader help : Display help message'
         )
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         HELP_STR = (
             'Use this bot with any of the following commands:'
             '\n* `@uploader <local_file_path>` : Upload a file, where `<local_file_path>` is the path to the file'

--- a/zulip_bots/zulip_bots/bots/flock/flock.py
+++ b/zulip_bots/zulip_bots/bots/flock/flock.py
@@ -1,6 +1,7 @@
 import logging
 import requests
 from typing import Any, Dict, List, Tuple, Optional
+from zulip_bots.lib import BotHandler
 from requests.exceptions import ConnectionError
 
 USERS_LIST_URL = 'https://api.flock.co/v1/roster.listContacts'
@@ -92,14 +93,14 @@ class FlockHandler:
     flock user without having to leave Zulip.
     '''
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('flock')
 
     def usage(self) -> str:
         return '''Hello from Flock Bot. You can send messages to any Flock user
 right from Zulip.'''
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         response = get_flock_bot_response(message['content'], self.config_info)
         bot_handler.send_reply(message, response)
 

--- a/zulip_bots/zulip_bots/bots/followup/followup.py
+++ b/zulip_bots/zulip_bots/bots/followup/followup.py
@@ -1,5 +1,6 @@
 # See readme.md for instructions on running this code.
-from typing import Dict, Any
+from typing import Dict
+from zulip_bots.lib import BotHandler
 
 class FollowupHandler:
     '''
@@ -23,11 +24,11 @@ class FollowupHandler:
             called "followup" that your API user can send to.
             '''
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('followup', optional=False)
         self.stream = self.config_info.get("stream", 'followup')
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         if message['content'] == '':
             bot_response = "Please specify the message you want to send to followup stream after @mention-bot"
             bot_handler.send_reply(message, bot_response)

--- a/zulip_bots/zulip_bots/bots/front/front.py
+++ b/zulip_bots/zulip_bots/bots/front/front.py
@@ -1,6 +1,7 @@
 import requests
 import re
 from typing import Any, Dict
+from zulip_bots.lib import BotHandler
 
 class FrontHandler:
     FRONT_API = "https://api2.frontapp.com/conversations/{}"
@@ -20,7 +21,7 @@ class FrontHandler:
             Front Bot, `front.conf` must be set up. See `doc.md` for more details.
             '''
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         config = bot_handler.get_config_info('front')
         api_key = config.get('api_key')
         if not api_key:
@@ -28,14 +29,14 @@ class FrontHandler:
 
         self.auth = "Bearer " + api_key
 
-    def help(self, bot_handler: Any) -> str:
+    def help(self, bot_handler: BotHandler) -> str:
         response = ""
         for command, description in self.COMMANDS:
             response += "`{}` {}\n".format(command, description)
 
         return response
 
-    def archive(self, bot_handler: Any) -> str:
+    def archive(self, bot_handler: BotHandler) -> str:
         response = requests.patch(self.FRONT_API.format(self.conversation_id),
                                   headers={"Authorization": self.auth},
                                   json={"status": "archived"})
@@ -45,7 +46,7 @@ class FrontHandler:
 
         return "Conversation was archived."
 
-    def delete(self, bot_handler: Any) -> str:
+    def delete(self, bot_handler: BotHandler) -> str:
         response = requests.patch(self.FRONT_API.format(self.conversation_id),
                                   headers={"Authorization": self.auth},
                                   json={"status": "deleted"})
@@ -55,7 +56,7 @@ class FrontHandler:
 
         return "Conversation was deleted."
 
-    def spam(self, bot_handler: Any) -> str:
+    def spam(self, bot_handler: BotHandler) -> str:
         response = requests.patch(self.FRONT_API.format(self.conversation_id),
                                   headers={"Authorization": self.auth},
                                   json={"status": "spam"})
@@ -65,7 +66,7 @@ class FrontHandler:
 
         return "Conversation was marked as spam."
 
-    def restore(self, bot_handler: Any) -> str:
+    def restore(self, bot_handler: BotHandler) -> str:
         response = requests.patch(self.FRONT_API.format(self.conversation_id),
                                   headers={"Authorization": self.auth},
                                   json={"status": "open"})
@@ -75,7 +76,7 @@ class FrontHandler:
 
         return "Conversation was restored."
 
-    def comment(self, bot_handler: Any, **kwargs: Any) -> str:
+    def comment(self, bot_handler: BotHandler, **kwargs: Any) -> str:
         response = requests.post(self.FRONT_API.format(self.conversation_id) + "/comments",
                                  headers={"Authorization": self.auth}, json=kwargs)
 
@@ -84,7 +85,7 @@ class FrontHandler:
 
         return "Comment was sent."
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         command = message['content']
 
         result = re.search(self.CNV_ID_REGEXP, message['subject'])

--- a/zulip_bots/zulip_bots/bots/giphy/giphy.py
+++ b/zulip_bots/zulip_bots/bots/giphy/giphy.py
@@ -1,4 +1,5 @@
-from typing import Dict, Any, Union
+from typing import Dict, Union
+from zulip_bots.lib import BotHandler
 import requests
 import logging
 from requests.exceptions import HTTPError, ConnectionError
@@ -40,10 +41,10 @@ class GiphyHandler:
                                   'Follow the instructions in doc.md for setting an API key.')
             raise ConfigValidationError(error_message)
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('giphy')
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         bot_response = get_bot_giphy_response(
             message,
             bot_handler,
@@ -81,7 +82,7 @@ def get_url_gif_giphy(keyword: str, api_key: str) -> Union[int, str]:
     return gif_url
 
 
-def get_bot_giphy_response(message: Dict[str, str], bot_handler: Any, config_info: Dict[str, str]) -> str:
+def get_bot_giphy_response(message: Dict[str, str], bot_handler: BotHandler, config_info: Dict[str, str]) -> str:
     # Each exception has a specific reply should "gif_url" return a number.
     # The bot will post the appropriate message for the error.
     keyword = message['content']

--- a/zulip_bots/zulip_bots/bots/github_detail/github_detail.py
+++ b/zulip_bots/zulip_bots/bots/github_detail/github_detail.py
@@ -4,6 +4,7 @@ import logging
 import requests
 
 from typing import Dict, Any, Tuple, Union
+from zulip_bots.lib import BotHandler
 
 class GithubHandler:
     '''
@@ -14,7 +15,7 @@ class GithubHandler:
     GITHUB_ISSUE_URL_TEMPLATE = 'https://api.github.com/repos/{owner}/{repo}/issues/{id}'
     HANDLE_MESSAGE_REGEX = re.compile(r"(?:([\w-]+)\/)?([\w-]+)?#(\d+)")
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('github_detail', optional=True)
         self.owner = self.config_info.get("owner", False)
         self.repo = self.config_info.get("repo", False)
@@ -64,7 +65,7 @@ class GithubHandler:
                 repo = self.repo
         return (owner, repo)
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         # Send help message
         if message['content'] == 'help':
             bot_handler.send_reply(message, self.usage())

--- a/zulip_bots/zulip_bots/bots/google_search/google_search.py
+++ b/zulip_bots/zulip_bots/bots/google_search/google_search.py
@@ -5,7 +5,8 @@ import requests
 
 from bs4 import BeautifulSoup
 
-from typing import Any, Dict, List
+from typing import Dict, List
+from zulip_bots.lib import BotHandler
 
 def google_search(keywords: str) -> List[Dict[str, str]]:
     query = {'q': keywords}
@@ -81,7 +82,7 @@ class GoogleSearchHandler:
             @mentioned-bot.
             '''
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         original_content = message['content']
         result = get_google_result(original_content)
         bot_handler.send_reply(message, result)

--- a/zulip_bots/zulip_bots/bots/helloworld/helloworld.py
+++ b/zulip_bots/zulip_bots/bots/helloworld/helloworld.py
@@ -1,6 +1,7 @@
 # See readme.md for instructions on running this code.
 
 from typing import Any, Dict
+from zulip_bots.lib import BotHandler
 
 class HelloWorldHandler:
     def usage(self) -> str:
@@ -12,7 +13,7 @@ class HelloWorldHandler:
         sophisticated, bots.
         '''
 
-    def handle_message(self, message: Dict[str, Any], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, Any], bot_handler: BotHandler) -> None:
         content = 'beep boop'  # type: str
         bot_handler.send_reply(message, content)
 

--- a/zulip_bots/zulip_bots/bots/help/help.py
+++ b/zulip_bots/zulip_bots/bots/help/help.py
@@ -1,5 +1,6 @@
 # See readme.md for instructions on running this code.
-from typing import Any, Dict
+from typing import Dict
+from zulip_bots.lib import BotHandler
 
 class HelpHandler:
     def usage(self) -> str:
@@ -12,7 +13,7 @@ class HelpHandler:
             your Zulip instance.
             '''
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         help_content = "Info on Zulip can be found here:\nhttps://github.com/zulip/zulip"
         bot_handler.send_reply(message, help_content)
 

--- a/zulip_bots/zulip_bots/bots/idonethis/idonethis.py
+++ b/zulip_bots/zulip_bots/bots/idonethis/idonethis.py
@@ -3,6 +3,7 @@ import logging
 import re
 
 from typing import Any, Dict, Optional, List
+from zulip_bots.lib import BotHandler
 
 API_BASE_URL = "https://beta.idonethis.com/api/v2"
 
@@ -128,7 +129,7 @@ More information in my help""")
     return "Great work :thumbs_up:. New entry `{}` created!".format(data['body_formatted'])
 
 class IDoneThisHandler:
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         global api_key, default_team
         self.config_info = bot_handler.get_config_info('idonethis')
         if 'api_key' in self.config_info:
@@ -179,7 +180,7 @@ Below are some of the commands you can use, and what they do.
     new entry `something` for the product team.
         ''' + default_team_message
 
-    def handle_message(self, message: Dict[str, Any], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, Any], bot_handler: BotHandler) -> None:
         bot_handler.send_reply(message, self.get_response(message))
 
     def get_response(self, message: Dict[str, Any]) -> str:

--- a/zulip_bots/zulip_bots/bots/incident/incident.py
+++ b/zulip_bots/zulip_bots/bots/incident/incident.py
@@ -1,6 +1,7 @@
 import json
 import re
 from typing import Any, Dict, Tuple
+from zulip_bots.lib import BotHandler
 
 QUESTION = 'How should we handle this?'
 
@@ -24,7 +25,7 @@ class IncidentHandler:
             glue code here should be pretty portable.
             '''
 
-    def handle_message(self, message: Dict[str, Any], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, Any], bot_handler: BotHandler) -> None:
         query = message['content']
         if query.startswith('new '):
             start_new_incident(query, message, bot_handler)
@@ -41,7 +42,7 @@ class IncidentHandler:
             bot_response = 'type "new <description>" for a new incident'
             bot_handler.send_reply(message, bot_response)
 
-def start_new_incident(query: str, message: Dict[str, Any], bot_handler: Any) -> None:
+def start_new_incident(query: str, message: Dict[str, Any], bot_handler: BotHandler) -> None:
     # Here is where we would enter the incident in some sort of backend
     # system.  We just simulate everything by having an incident id that
     # we generate here.

--- a/zulip_bots/zulip_bots/bots/incrementor/incrementor.py
+++ b/zulip_bots/zulip_bots/bots/incrementor/incrementor.py
@@ -1,6 +1,7 @@
 # See readme.md for instructions on running this code.
 
-from typing import Dict, Any
+from typing import Dict
+from zulip_bots.lib import BotHandler
 
 class IncrementorHandler:
     META = {
@@ -16,13 +17,13 @@ class IncrementorHandler:
         is @-mentioned, this number will be incremented in the same message.
         '''
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         storage = bot_handler.storage
         if not storage.contains('number') or not storage.contains('message_id'):
             storage.put('number', 0)
             storage.put('message_id', None)
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         storage = bot_handler.storage
         num = storage.get('number')
 
@@ -33,7 +34,8 @@ class IncrementorHandler:
         storage.put('number', num)
         if storage.get('message_id') is None:
             result = bot_handler.send_reply(message, str(num))
-            storage.put('message_id', result['id'])
+            if result is not None:
+                storage.put('message_id', result['id'])
         else:
             bot_handler.update_message(dict(
                 message_id=storage.get('message_id'),

--- a/zulip_bots/zulip_bots/bots/jira/jira.py
+++ b/zulip_bots/zulip_bots/bots/jira/jira.py
@@ -2,6 +2,7 @@ import base64
 import re
 import requests
 from typing import Any, Dict, Optional
+from zulip_bots.lib import BotHandler
 
 GET_REGEX = re.compile('get "(?P<issue_key>.+)"$')
 CREATE_REGEX = re.compile(
@@ -149,7 +150,7 @@ class JiraHandler:
         Jira Bot, `jira.conf` must be set up. See `doc.md` for more details.
         '''
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         config = bot_handler.get_config_info('jira')
 
         username = config.get('username')
@@ -198,7 +199,7 @@ class JiraHandler:
 
         return response
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         content = message.get('content')
         response = ''
 

--- a/zulip_bots/zulip_bots/bots/link_shortener/link_shortener.py
+++ b/zulip_bots/zulip_bots/bots/link_shortener/link_shortener.py
@@ -2,6 +2,7 @@ import re
 import requests
 
 from typing import Any, Dict
+from zulip_bots.lib import BotHandler
 
 class LinkShortenerHandler:
     '''A Zulip bot that will shorten URLs ("links") in a conversation using the
@@ -14,11 +15,11 @@ class LinkShortenerHandler:
             'any URLs you want to shorten in the body of the message. \n\n'
             '`key` must be set in `link_shortener.conf`.')
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('link_shortener')
         self.check_api_key(bot_handler)
 
-    def check_api_key(self, bot_handler: Any) -> None:
+    def check_api_key(self, bot_handler: BotHandler) -> None:
         test_request_data = self.call_link_shorten_service('www.youtube.com/watch')  # type: Any
         try:
             if self.is_invalid_token_error(test_request_data):
@@ -29,7 +30,7 @@ class LinkShortenerHandler:
     def is_invalid_token_error(self, response_json: Any) -> bool:
         return response_json['status_code'] == 500 and response_json['status_txt'] == 'INVALID_ARG_ACCESS_TOKEN'
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         REGEX_STR = (
             r'('
             r'(?:http|https):\/\/'  # This allows for the HTTP or HTTPS

--- a/zulip_bots/zulip_bots/bots/mention/mention.py
+++ b/zulip_bots/zulip_bots/bots/mention/mention.py
@@ -2,16 +2,17 @@
 
 import requests
 from typing import Any, List, Dict
+from zulip_bots.lib import BotHandler
 
 class MentionHandler:
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('mention')
         self.access_token = self.config_info['access_token']
         self.account_id = ''
 
         self.check_access_token(bot_handler)
 
-    def check_access_token(self, bot_handler: Any) -> None:
+    def check_access_token(self, bot_handler: BotHandler) -> None:
         test_query_header = {
             'Authorization': 'Bearer ' + self.access_token,
             'Accept-Version': '1.15',
@@ -33,7 +34,7 @@ class MentionHandler:
         Version 1.00
         '''
 
-    def handle_message(self, message: Dict[str, Any], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, Any], bot_handler: BotHandler) -> None:
         message['content'] = message['content'].strip()
 
         if message['content'].lower() == 'help':

--- a/zulip_bots/zulip_bots/bots/monkeytestit/monkeytestit.py
+++ b/zulip_bots/zulip_bots/bots/monkeytestit/monkeytestit.py
@@ -1,6 +1,6 @@
 import logging
-from typing import Dict, Any
-
+from typing import Dict
+from zulip_bots.lib import BotHandler
 from zulip_bots.bots.monkeytestit.lib import parse
 from zulip_bots.lib import NoBotConfigException
 
@@ -15,7 +15,7 @@ class MonkeyTestitBot:
                "that, to perform a check, mention me and add the website.\n\n" \
                "Check doc.md for more options and setup instructions."
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         try:
             self.config = bot_handler.get_config_info('monkeytestit')
         except NoBotConfigException:
@@ -41,7 +41,7 @@ class MonkeyTestitBot:
                              " your api_key value and try again.")
 
     def handle_message(self, message: Dict[str, str],
-                       bot_handler: Any) -> None:
+                       bot_handler: BotHandler) -> None:
         content = message['content']
 
         response = parse.execute(content, self.api_key)

--- a/zulip_bots/zulip_bots/bots/salesforce/salesforce.py
+++ b/zulip_bots/zulip_bots/bots/salesforce/salesforce.py
@@ -2,6 +2,7 @@
 
 import simple_salesforce
 from typing import Dict, Any, List
+from zulip_bots.lib import BotHandler
 import re
 import logging
 from zulip_bots.bots.salesforce.utils import commands, object_types, link_query, default_query
@@ -151,7 +152,7 @@ class SalesforceHandler:
                         return 'Usage: {} [arguments]'.format(command['template'])
         return get_help_text()
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('salesforce')
         try:
             self.sf = simple_salesforce.Salesforce(
@@ -162,12 +163,12 @@ class SalesforceHandler:
         except simple_salesforce.exceptions.SalesforceAuthenticationFailed as err:
             bot_handler.quit('Failed to log in to Salesforce. {} {}'.format(err.code, err.message))
 
-    def handle_message(self, message: Dict[str, Any], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, Any], bot_handler: BotHandler) -> None:
         try:
             bot_response = self.get_salesforce_response(message['content'])
             bot_handler.send_reply(message, bot_response)
         except Exception as e:
-            bot_handler.send_reply('Error. {}.'.format(e), bot_response)
+            bot_handler.send_reply(message, 'Error. {}.'.format(e), bot_response)
 
 
 handler_class = SalesforceHandler

--- a/zulip_bots/zulip_bots/bots/stack_overflow/stack_overflow.py
+++ b/zulip_bots/zulip_bots/bots/stack_overflow/stack_overflow.py
@@ -1,7 +1,8 @@
 import requests
 import logging
 
-from typing import Optional, Any, Dict
+from typing import Optional, Dict
+from zulip_bots.lib import BotHandler
 
 # See readme.md for instructions on running this code.
 
@@ -28,11 +29,11 @@ class StackOverflowHandler:
             should preface query with "@mention-bot".
             @mention-bot <search query>'''
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         bot_response = self.get_bot_stackoverflow_response(message, bot_handler)
         bot_handler.send_reply(message, bot_response)
 
-    def get_bot_stackoverflow_response(self, message: Dict[str, str], bot_handler: Any) -> Optional[str]:
+    def get_bot_stackoverflow_response(self, message: Dict[str, str], bot_handler: BotHandler) -> Optional[str]:
         '''This function returns the URLs of the requested topic.'''
 
         help_text = 'Please enter your query after @mention-bot to search StackOverflow'

--- a/zulip_bots/zulip_bots/bots/susi/susi.py
+++ b/zulip_bots/zulip_bots/bots/susi/susi.py
@@ -1,5 +1,6 @@
 import requests
-from typing import Any, Dict
+from typing import Dict
+from zulip_bots.lib import BotHandler
 
 class SusiHandler:
     '''
@@ -34,7 +35,7 @@ class SusiHandler:
     ```
         '''
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         msg = message['content']
         if msg == 'help' or msg == '':
             bot_handler.send_reply(message, self.usage())

--- a/zulip_bots/zulip_bots/bots/trello/test_trello.py
+++ b/zulip_bots/zulip_bots/bots/trello/test_trello.py
@@ -53,7 +53,7 @@ class TestTrelloBot(BotTestCase, DefaultTests):
 
             with self.mock_http_conversation('get_board_descs'):
                 bot_instance = TrelloHandler()
-                bot_instance.initialize(StubBotHandler)
+                bot_instance.initialize(StubBotHandler())
 
                 self.assertEqual(bot_instance.get_board_descs(['TEST']), '1.[TEST](TEST) (`TEST`)')
 

--- a/zulip_bots/zulip_bots/bots/trello/trello.py
+++ b/zulip_bots/zulip_bots/bots/trello/trello.py
@@ -1,5 +1,5 @@
 from typing import Any, List, Dict
-
+from zulip_bots.lib import BotHandler
 import requests
 
 supported_commands = [
@@ -15,7 +15,7 @@ INVALID_ARGUMENTS_ERROR_MESSAGE = 'Invalid Arguments.'
 RESPONSE_ERROR_MESSAGE = 'Invalid Response. Please check configuration and parameters.'
 
 class TrelloHandler:
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('trello')
         self.api_key = self.config_info['api_key']
         self.access_token = self.config_info['access_token']
@@ -28,7 +28,7 @@ class TrelloHandler:
 
         self.check_access_token(bot_handler)
 
-    def check_access_token(self, bot_handler: Any) -> None:
+    def check_access_token(self, bot_handler: BotHandler) -> None:
         test_query_response = requests.get('https://api.trello.com/1/members/{}/'.format(self.user_name),
                                            params=self.auth_params)
 
@@ -42,7 +42,7 @@ class TrelloHandler:
         Use `list-commands` to get information about the supported commands.
         '''
 
-    def handle_message(self, message: Dict[str, Any], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, Any], bot_handler: BotHandler) -> None:
         content = message['content'].strip().split()
 
         if content == []:

--- a/zulip_bots/zulip_bots/bots/trivia_quiz/trivia_quiz.py
+++ b/zulip_bots/zulip_bots/bots/trivia_quiz/trivia_quiz.py
@@ -4,6 +4,7 @@ import requests
 import random
 import re
 from typing import Optional, Any, Dict, Tuple
+from zulip_bots.lib import BotHandler
 
 class NotAvailableException(Exception):
     pass
@@ -17,7 +18,7 @@ class TriviaQuizHandler:
             This plugin will give users a trivia question from
             the open trivia database at opentdb.com.'''
 
-    def handle_message(self, message: Dict[str, Any], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, Any], bot_handler: BotHandler) -> None:
         query = message['content']
         if query == 'new':
             try:
@@ -51,10 +52,10 @@ class TriviaQuizHandler:
             bot_response = 'type "new" for a new question'
         bot_handler.send_reply(message, bot_response)
 
-def get_quiz_from_id(quiz_id: str, bot_handler: Any) -> str:
+def get_quiz_from_id(quiz_id: str, bot_handler: BotHandler) -> str:
     return bot_handler.storage.get(quiz_id)
 
-def start_new_quiz(message: Dict[str, Any], bot_handler: Any) -> None:
+def start_new_quiz(message: Dict[str, Any], bot_handler: BotHandler) -> None:
     quiz = get_trivia_quiz()
     quiz_id = generate_quiz_id(bot_handler.storage)
     bot_response = format_quiz_for_markdown(quiz_id, quiz)
@@ -197,7 +198,7 @@ Q: {question}
     )
     return content
 
-def update_quiz(quiz: Dict[str, Any], quiz_id: str, bot_handler: Any) -> None:
+def update_quiz(quiz: Dict[str, Any], quiz_id: str, bot_handler: BotHandler) -> None:
     bot_handler.storage.put(quiz_id, json.dumps(quiz))
 
 def build_response(is_correct: bool, num_answers: int) -> str:
@@ -211,7 +212,7 @@ def build_response(is_correct: bool, num_answers: int) -> str:
     return response
 
 def handle_answer(quiz: Dict[str, Any], option: str, quiz_id: str,
-                  bot_handler: Any, sender_name: str) -> Tuple[bool, str]:
+                  bot_handler: BotHandler, sender_name: str) -> Tuple[bool, str]:
     answer = quiz['answers'][quiz['correct_letter']]
     is_new_answer = (option not in quiz['answered_options'])
     if is_new_answer:

--- a/zulip_bots/zulip_bots/bots/twitpost/twitpost.py
+++ b/zulip_bots/zulip_bots/bots/twitpost/twitpost.py
@@ -1,6 +1,6 @@
 import tweepy
-from typing import Any, Dict
-
+from typing import Dict
+from zulip_bots.lib import BotHandler
 
 class TwitpostBot:
 
@@ -16,7 +16,7 @@ class TwitpostBot:
                    "Example:\n" \
                    " * @twitpost tweet hey batman\n"
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('twitter')
         auth = tweepy.OAuthHandler(self.config_info['consumer_key'],
                                    self.config_info['consumer_secret'])
@@ -24,7 +24,7 @@ class TwitpostBot:
                               self.config_info['access_token_secret'])
         self.api = tweepy.API(auth, parser=tweepy.parsers.JSONParser())
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         content = message["content"]
 
         if content.strip() == '':

--- a/zulip_bots/zulip_bots/bots/virtual_fs/virtual_fs.py
+++ b/zulip_bots/zulip_bots/bots/virtual_fs/virtual_fs.py
@@ -4,6 +4,7 @@ import re
 import os
 
 from typing import Any, Dict, List, Set, Tuple, Union
+from zulip_bots.lib import BotHandler
 
 class VirtualFsHandler:
     META = {
@@ -14,7 +15,7 @@ class VirtualFsHandler:
     def usage(self) -> str:
         return get_help()
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         command = message['content']
         if command == "":
             command = "help"

--- a/zulip_bots/zulip_bots/bots/weather/weather.py
+++ b/zulip_bots/zulip_bots/bots/weather/weather.py
@@ -2,16 +2,17 @@
 import requests
 
 from typing import Any, Dict
+from zulip_bots.lib import BotHandler
 
 api_url = 'http://api.openweathermap.org/data/2.5/weather'
 
 class WeatherHandler:
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.api_key = bot_handler.get_config_info('weather')['key']
         self.response_pattern = 'Weather in {}, {}:\n{:.2f} F / {:.2f} C\n{}'
         self.check_api_key(bot_handler)
 
-    def check_api_key(self, bot_handler: Any) -> None:
+    def check_api_key(self, bot_handler: BotHandler) -> None:
         api_params = dict(q='nyc', APPID=self.api_key)
         test_response = requests.get(api_url, params=api_params)
         try:
@@ -26,7 +27,7 @@ class WeatherHandler:
             This plugin will give info about weather in a specified city
             '''
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         help_content = '''
             This bot returns weather info for specified city.
             You specify city in the following format:

--- a/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
+++ b/zulip_bots/zulip_bots/bots/wikipedia/wikipedia.py
@@ -1,6 +1,7 @@
 import requests
 import logging
-from typing import Optional, Any, Dict
+from typing import Dict
+from zulip_bots.lib import BotHandler
 
 # See readme.md for instructions on running this code.
 
@@ -29,11 +30,11 @@ class WikipediaHandler:
             should preface searches with "@mention-bot".
             @mention-bot <name of article>'''
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         bot_response = self.get_bot_wiki_response(message, bot_handler)
         bot_handler.send_reply(message, bot_response)
 
-    def get_bot_wiki_response(self, message: Dict[str, str], bot_handler: Any) -> Optional[str]:
+    def get_bot_wiki_response(self, message: Dict[str, str], bot_handler: BotHandler) -> str:
         '''This function returns the URLs of the requested topic.'''
 
         help_text = 'Please enter your search term after {}'

--- a/zulip_bots/zulip_bots/bots/witai/witai.py
+++ b/zulip_bots/zulip_bots/bots/witai/witai.py
@@ -1,6 +1,7 @@
 # See readme.md for instructions on running this code.
 
 from typing import Dict, Any, Optional, Callable
+from zulip_bots.lib import BotHandler
 import wit
 import importlib.util
 
@@ -11,7 +12,7 @@ class WitaiHandler:
         Wit.ai bot, `witai.conf` must be set up. See `doc.md` for more details.
         '''
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         config = bot_handler.get_config_info('witai')
 
         token = config.get('token')
@@ -36,7 +37,7 @@ class WitaiHandler:
 
         self.client = wit.Wit(token)
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         if message['content'] == '' or message['content'] == 'help':
             bot_handler.send_reply(message, self.help_message)
             return

--- a/zulip_bots/zulip_bots/bots/xkcd/xkcd.py
+++ b/zulip_bots/zulip_bots/bots/xkcd/xkcd.py
@@ -3,7 +3,8 @@ import random
 import logging
 import requests
 
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
+from zulip_bots.lib import BotHandler
 
 XKCD_TEMPLATE_URL = 'https://xkcd.com/%s/info.0.json'
 LATEST_XKCD_URL = 'https://xkcd.com/info.0.json'
@@ -34,7 +35,7 @@ class XkcdHandler:
             `<comic_id>`, e.g `@mention-bot 1234`.
             '''
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         quoted_name = bot_handler.identity().mention
         xkcd_bot_response = get_xkcd_bot_response(message, quoted_name)
         bot_handler.send_reply(message, xkcd_bot_response)

--- a/zulip_bots/zulip_bots/bots/yoda/yoda.py
+++ b/zulip_bots/zulip_bots/bots/yoda/yoda.py
@@ -3,7 +3,8 @@ import logging
 import ssl
 import requests
 
-from typing import Any, Dict
+from typing import Dict
+from zulip_bots.lib import BotHandler
 
 HELP_MESSAGE = '''
             This bot allows users to translate a sentence into
@@ -32,7 +33,7 @@ class YodaSpeakHandler:
     This bot will allow users to translate a sentence into 'Yoda speak'.
     It looks for messages starting with '@mention-bot'.
     '''
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.api_key = bot_handler.get_config_info('yoda')['api_key']
 
     def usage(self) -> str:
@@ -49,7 +50,7 @@ class YodaSpeakHandler:
             @mention-bot You will learn how to speak like me someday.
             '''
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         self.handle_input(message, bot_handler)
 
     def send_to_yoda_api(self, sentence: str) -> str:
@@ -83,7 +84,7 @@ class YodaSpeakHandler:
         sentence = message_content.replace(' ', '+')
         return sentence
 
-    def handle_input(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_input(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
         original_content = message['content']
 
         if self.is_help(original_content) or (original_content == ""):
@@ -108,7 +109,7 @@ class YodaSpeakHandler:
 
             bot_handler.send_reply(message, reply_message)
 
-    def send_message(self, bot_handler: Any, message: str, stream: str, subject: str) -> None:
+    def send_message(self, bot_handler: BotHandler, message: str, stream: str, subject: str) -> None:
         # function for sending a message
         bot_handler.send_message(dict(
             type='stream',

--- a/zulip_bots/zulip_bots/bots/youtube/youtube.py
+++ b/zulip_bots/zulip_bots/bots/youtube/youtube.py
@@ -2,7 +2,8 @@ import requests
 import logging
 
 from requests.exceptions import HTTPError, ConnectionError
-from typing import Dict, Any, Union, List, Tuple, Optional
+from typing import Dict, Union, List, Tuple, Optional
+from zulip_bots.lib import BotHandler
 
 commands_list = ('list', 'top', 'help')
 
@@ -23,7 +24,7 @@ class YoutubeHandler:
                    " * @mention-bot funny cats\n" \
                    " * @mention-bot list funny dogs"
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.config_info = bot_handler.get_config_info('youtube')
         # Check if API key is valid. If it is not valid, don't run the bot.
         try:
@@ -37,7 +38,7 @@ class YoutubeHandler:
         except ConnectionError:
             logging.warning('Bad connection')
 
-    def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
 
         if message['content'] == '' or message['content'] == 'help':
             bot_handler.send_reply(message, self.help_content)

--- a/zulip_bots/zulip_bots/game_handler.py
+++ b/zulip_bots/zulip_bots/game_handler.py
@@ -2,6 +2,7 @@ import json
 import re
 import random
 import logging
+from zulip_bots.lib import BotHandler
 from copy import deepcopy
 from typing import Any, Dict, Tuple, List
 
@@ -174,13 +175,13 @@ class GameAdapter:
         @bot-name help
         '''
 
-    def initialize(self, bot_handler: Any) -> None:
+    def initialize(self, bot_handler: BotHandler) -> None:
         self.bot_handler = bot_handler
         self.get_user_cache()
         self.email = self.bot_handler.email
         self.full_name = self.bot_handler.full_name
 
-    def handle_message(self, message: Dict[str, Any], bot_handler: Any) -> None:
+    def handle_message(self, message: Dict[str, Any], bot_handler: BotHandler) -> None:
         try:
             self.bot_handler = bot_handler
             content = message['content'].strip()

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -112,6 +112,37 @@ class BotStorage(Protocol):
     def contains(self, key: Text) -> bool:
         ...
 
+class BotHandler(Protocol):
+
+    user_id: int
+    email: str
+    full_name: str
+
+    @property
+    def storage(self) -> BotStorage:
+        ...
+
+    def identity(self) -> BotIdentity:
+        ...
+
+    def react(self, message: Dict[str, Any], emoji_name: str) -> Dict[str, Any]:
+        ...
+
+    def send_message(self, message: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        ...
+
+    def send_reply(self, message: Dict[str, Any], response: str, widget_content: Optional[str] = None) -> Optional[Dict[str, Any]]:
+        ...
+
+    def update_message(self, message: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        ...
+
+    def get_config_info(self, bot_name: str, optional: bool = False) -> Dict[str, str]:
+        ...
+
+    def quit(self, message: str = "") -> None:
+        ...
+
 class ExternalBotHandler:
     def __init__(
         self,
@@ -168,7 +199,7 @@ class ExternalBotHandler:
                                               emoji_name=emoji_name,
                                               reaction_type='unicode_emoji'))
 
-    def send_message(self, message: (Dict[str, Any])) -> Dict[str, Any]:
+    def send_message(self, message: Dict[str, Any]) -> Dict[str, Any]:
         if not self._rate_limit.is_legal():
             self._rate_limit.show_error_and_exit()
         resp = self._client.send_message(message)
@@ -198,7 +229,7 @@ class ExternalBotHandler:
             self._rate_limit.show_error_and_exit()
         return self._client.update_message(message)
 
-    def get_config_info(self, bot_name: str, optional: Optional[bool] = False) -> Dict[str, Any]:
+    def get_config_info(self, bot_name: str, optional: bool = False) -> Dict[str, str]:
         if self._bot_config_parser is not None:
             config_parser = self._bot_config_parser
         else:

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -9,7 +9,7 @@ import re
 
 
 from typing import Any, Optional, List, Dict, IO, Text
-
+from typing_extensions import Protocol
 from zulip import Client, ZulipError
 
 
@@ -101,6 +101,16 @@ class BotIdentity:
         self.name = name
         self.email = email
         self.mention = '@**' + name + '**'
+
+class BotStorage(Protocol):
+    def put(self, key: Text, value: Any) -> None:
+        ...
+
+    def get(self, key: Text) -> Any:
+        ...
+
+    def contains(self, key: Text) -> bool:
+        ...
 
 class ExternalBotHandler:
     def __init__(

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -295,7 +295,7 @@ class ExternalBotHandler:
         sys.exit(message)
 
 
-def extract_query_without_mention(message: Dict[str, Any], client: ExternalBotHandler) -> Optional[str]:
+def extract_query_without_mention(message: Dict[str, Any], client: BotHandler) -> Optional[str]:
     """
     If the bot is the first @mention in the message, then this function returns
     the stripped message with the bot's @mention removed.  Otherwise, it returns None.
@@ -314,7 +314,7 @@ def extract_query_without_mention(message: Dict[str, Any], client: ExternalBotHa
     return None
 
 
-def is_private_message_but_not_group_pm(message_dict: Dict[str, Any], current_user: ExternalBotHandler) -> bool:
+def is_private_message_but_not_group_pm(message_dict: Dict[str, Any], current_user: BotHandler) -> bool:
     """
     Checks whether a message dict represents a PM from another user.
 

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -335,7 +335,7 @@ def display_config_file_errors(error_msg: str, config_file: str) -> None:
     print('\nMore details here:\n\n{}\n'.format(error_msg))
 
 
-def prepare_message_handler(bot: str, bot_handler: ExternalBotHandler, bot_lib_module: Any) -> Any:
+def prepare_message_handler(bot: str, bot_handler: BotHandler, bot_lib_module: Any) -> Any:
     message_handler = bot_lib_module.handler_class()
     if hasattr(message_handler, 'validate_config'):
         config_data = bot_handler.get_config_info(bot)

--- a/zulip_bots/zulip_bots/test_lib.py
+++ b/zulip_bots/zulip_bots/test_lib.py
@@ -28,6 +28,7 @@ class StubBotHandler:
         self.storage = SimpleStorage()
         self.full_name = 'test-bot'
         self.email = 'test-bot@example.com'
+        self.user_id = 0
         self.message_server = SimpleMessageServer()
         self.reset_transcript()
 
@@ -69,7 +70,7 @@ class StubBotHandler:
     def quit(self, message: str = "") -> None:
         raise self.BotQuitException()
 
-    def get_config_info(self, bot_name: str, optional: bool = False) -> Dict[str, Any]:
+    def get_config_info(self, bot_name: str, optional: bool = False) -> Dict[str, str]:
         return {}
 
     def unique_reply(self) -> Dict[str, Any]:

--- a/zulip_botserver/tests/test_server.py
+++ b/zulip_botserver/tests/test_server.py
@@ -1,6 +1,7 @@
 import mock
 import os
 from typing import Any, Dict
+from zulip_bots.lib import BotHandler
 import unittest
 from .server_test_lib import BotServerTestCase
 import json
@@ -14,7 +15,7 @@ from zulip_botserver.input_parameters import parse_args
 
 class BotServerTests(BotServerTestCase):
     class MockMessageHandler:
-        def handle_message(self, message: Dict[str, str], bot_handler: Any) -> None:
+        def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
             assert message == {'key': "test message"}
 
     class MockLibModule:


### PR DESCRIPTION
- zulip-bots: Add `CommonStorage` Protocol.
   -  The `CommonStorage` Protocol is created to add a
  Common type to all Storage Classes.
   -  The Storages used in `BotHandler`s are typed as `CommonStorage`

    Note: Protocol is imported from `typing_extensions` as `typing `doesn't
    provide Protocol for python <= 3.7.

- zulip-bots: Add `BotHandler` Protocol.

     The `BotHandler` Protocol has methods which allow
     any of the Current BotHandlers to use `BotHandler` Protocol
     as a mypy type.

    Fixes part of #639

- zulip-bots: Set `bot_handler` type to `BotHandler`.
    - Set `bot_handler` type to `BotHandler`.
    - Fix mypy issues in improperly typed variables and returns.

    Fixes #639