### PR TITLE
API: Rename list_subscriptions to get_subscriptions.

### DIFF
--- a/zulip/integrations/bridge_with_irc/irc_mirror_backend.py
+++ b/zulip/integrations/bridge_with_irc/irc_mirror_backend.py
@@ -36,7 +36,7 @@ class IRCBot(irc.bot.SingleServerIRCBot):
         print("Listening now. Please send an IRC message to verify operation")
 
     def check_subscription_or_die(self) -> None:
-        resp = self.zulip_client.list_subscriptions()
+        resp = self.zulip_client.get_subscriptions()
         if resp["result"] != "success":
             print("ERROR: %s" % (resp["msg"],))
             exit(1)

--- a/zulip/integrations/jabber/jabber_mirror_backend.py
+++ b/zulip/integrations/jabber/jabber_mirror_backend.py
@@ -275,7 +275,7 @@ def get_rooms(zulipToJabber: ZulipToJabberBot) -> List[str]:
     if options.mode == 'public':
         stream_infos = get_stream_infos("streams", zulipToJabber.client.get_streams)
     else:
-        stream_infos = get_stream_infos("subscriptions", zulipToJabber.client.list_subscriptions)
+        stream_infos = get_stream_infos("subscriptions", zulipToJabber.client.get_subscriptions)
 
     rooms = []  # type: List[str]
     for stream_info in stream_infos:

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -1288,6 +1288,11 @@ class Client:
             request=request,
         )
 
+    def list_subscriptions(self, request: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        logger.warning("list_subscriptions() is deprecated."
+                       " Please use get_subscriptions() instead.")
+        return self.get_subscriptions(request)
+
     def add_subscriptions(self, streams: Iterable[Dict[str, Any]], **kwargs: Any) -> Dict[str, Any]:
         '''
             See examples/subscribe for example usage.

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -1278,9 +1278,9 @@ class Client:
             }
         )
 
-    def list_subscriptions(self, request: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def get_subscriptions(self, request: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         '''
-            See examples/list-subscriptions for example usage.
+            See examples/get-subscriptions for example usage.
         '''
         return self.call_endpoint(
             url='users/me/subscriptions',

--- a/zulip/zulip/examples/get-subscriptions
+++ b/zulip/zulip/examples/get-subscriptions
@@ -18,4 +18,4 @@ options = parser.parse_args()
 
 client = zulip.init_from_options(options)
 
-print(client.list_subscriptions())
+print(client.get_subscriptions())


### PR DESCRIPTION
I replaced every occurrences of list_subscriptions and list-subscriptions except for https://github.com/zulip/python-zulip-api/blob/5b5fda2354f4488693f0f00def68eb8a9b426e67/zulip_bots/zulip_bots/bots/baremetrics/test_baremetrics.py#L68-L75 and list-subscriptions in baremetrics.