### PR TITLE
api: Add sorting for API responses.

### DIFF
--- a/test_function.py
+++ b/test_function.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import zulip
+
+# Pass the path to your zuliprc file here.
+client = zulip.Client(config_file="~/zuliprc")
+
+# Get all streams that the user is subscribed to
+result = client.list_subscriptions()
+print(result)

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -609,8 +609,8 @@ class Client:
             if v is not None:
                 marshalled_request[k] = v
         versioned_url = API_VERSTRING + (url if url is not None else "")
-        return self.do_api_query(marshalled_request, versioned_url, method=method,
-                                 longpolling=longpolling, files=files, timeout=timeout)
+        return json.dumps(self.do_api_query(marshalled_request, versioned_url, method=method,
+                                 longpolling=longpolling, files=files, timeout=timeout), sort_keys=True)
 
     def call_on_each_event(
         self,


### PR DESCRIPTION
Currently the API response keys were sorted in random order, making
the responses unreadable. Added JSON dumps to sort the response keys.
Fixes https://github.com/zulip/zulip/issues/17428