### PR TITLE
zulip-bots: Fix incrementor to handle edit time limit error.

### DIFF
--- a/zulip_bots/zulip_bots/bots/incrementor/incrementor.py
+++ b/zulip_bots/zulip_bots/bots/incrementor/incrementor.py
@@ -32,15 +32,20 @@ class IncrementorHandler:
         num = int(num) + 1
 
         storage.put('number', num)
-        if storage.get('message_id') is None:
-            result = bot_handler.send_reply(message, str(num))
-            if result is not None:
-                storage.put('message_id', result['id'])
-        else:
-            bot_handler.update_message(dict(
+        if storage.get('message_id') is not None:
+            result = bot_handler.update_message(dict(
                 message_id=storage.get('message_id'),
                 content=str(num)
             ))
+
+            # When there isn't an error while updating the message, we won't
+            # attempt to send the it again.
+            if result is None or result.get('result') != 'error':
+                return
+
+        message_info = bot_handler.send_reply(message, str(num))
+        if message_info is not None:
+            storage.put('message_id', message_info['id'])
 
 
 handler_class = IncrementorHandler

--- a/zulip_bots/zulip_bots/bots/incrementor/test_incrementor.py
+++ b/zulip_bots/zulip_bots/bots/incrementor/test_incrementor.py
@@ -29,3 +29,27 @@ class TestIncrementorBot(BotTestCase, DefaultTests):
             for item in m.call_args_list
         ]
         self.assertEqual(content_updates, ['2', '3', '4'])
+
+    def test_bot_edit_timeout(self) -> None:
+        bot = get_bot_message_handler(self.bot_name)
+        bot_handler = StubBotHandler()
+
+        message = dict(type='stream')
+
+        bot.initialize(bot_handler)
+        bot.handle_message(message, bot_handler)
+
+        error_msg = dict(msg='The time limit for editing this message has passed', result='error')
+        with patch('zulip_bots.test_lib.StubBotHandler.update_message', return_value=error_msg):
+            with patch('zulip_bots.simple_lib.SimpleMessageServer.send') as m:
+                bot.handle_message(message, bot_handler)
+                bot.handle_message(message, bot_handler)
+
+        # When there is an error, the bot should resend the message with the new value.
+        self.assertEqual(m.call_count, 2)
+
+        content_updates = [
+            item[0][0]['content']
+            for item in m.call_args_list
+        ]
+        self.assertEqual(content_updates, ['2', '3'])


### PR DESCRIPTION
#673 

This allows the incrementor to regard the error message from the server (such as having the edit time limit expired). It also adds a test for this feature. 
If the API returns an error message when the incrementor attempts to update a message, the incrementor will send a new message instead.