### PR TITLE
sync-public-streams: Fix for Python 3

### DIFF
--- a/zulip/integrations/zephyr/sync-public-streams
+++ b/zulip/integrations/zephyr/sync-public-streams
@@ -13,7 +13,7 @@ import zulip
 
 from typing import Set, Optional
 
-def fetch_public_streams() -> Optional[Set[bytes]]:
+def fetch_public_streams() -> Optional[Set[str]]:
     public_streams = set()
 
     try:
@@ -31,10 +31,10 @@ def fetch_public_streams() -> Optional[Set[bytes]]:
         stream_name = stream["name"]
         # Zephyr class names are canonicalized by first applying NFKC
         # normalization and then lower-casing server-side
-        canonical_cls = unicodedata.normalize("NFKC", stream_name).lower().encode("utf-8")
-        if canonical_cls in [b'security', b'login', b'network', b'ops', b'user_locate',
-                             b'mit', b'moof', b'wsmonitor', b'wg_ctl', b'winlogger',
-                             b'hm_ctl', b'hm_stat', b'zephyr_admin', b'zephyr_ctl']:
+        canonical_cls = unicodedata.normalize("NFKC", stream_name).lower()
+        if canonical_cls in ['security', 'login', 'network', 'ops', 'user_locate',
+                             'mit', 'moof', 'wsmonitor', 'wg_ctl', 'winlogger',
+                             'hm_ctl', 'hm_stat', 'zephyr_admin', 'zephyr_ctl']:
             # These zephyr classes cannot be subscribed to by us, due
             # to MIT's Zephyr access control settings
             continue


### PR DESCRIPTION
`bytes` are not JSON serializable.