### PR TITLE
zulip: Replace GET realm/filters with realm/linkifiers.

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -900,15 +900,25 @@ class Client:
             method='DELETE',
         )
 
-    def get_realm_filters(self) -> Dict[str, Any]:
+    def get_realm_linkifiers(self) -> Dict[str, Any]:
         '''
             Example usage:
 
-            >>> client.get_realm_filters()
-            {'result': 'success', 'msg': '', 'filters': [['#(?P<id>[0-9]+)', 'https://github.com/zulip/zulip/issues/%(id)s', 1]]}
+            >>> client.get_realm_linkifiers()
+            {
+                'result': 'success',
+                'msg': '',
+                'linkifiers': [
+                    {
+                        'id': 1,
+                        'pattern': #(?P<id>[0-9]+)',
+                        'url_format': 'https://github.com/zulip/zulip/issues/%(id)s',
+                    },
+                ]
+            }
         '''
         return self.call_endpoint(
-            url='realm/filters',
+            url='realm/linkifiers',
             method='GET',
         )
 


### PR DESCRIPTION
In zulip/zulip@3947b0c80a26b9126540ada996f027aac03063b7, we replaced
the legacy endpoint to use the term "linkifier" instead of
"filter" and to return the data in a dictionary format.

None of the official clients currently actually use this
endpoint.