### PR TITLE
botserver: Return a valid JSON that is acceptable to outgoing webhooks.

### DIFF
--- a/zulip_botserver/zulip_botserver/server.py
+++ b/zulip_botserver/zulip_botserver/server.py
@@ -195,11 +195,11 @@ def handle_bot() -> str:
         # In that case, the message shall not be handled.
         message['content'] = lib.extract_query_without_mention(message=message, client=bot_handler)
         if message['content'] is None:
-            return json.dumps("")
+            return json.dumps(dict(response_not_required=True))
 
     if is_private_message or is_mentioned:
         message_handler.handle_message(message=message, bot_handler=bot_handler)
-    return json.dumps("")
+    return json.dumps(dict(response_not_required=True))
 
 
 def main() -> None:


### PR DESCRIPTION
In zulip/zulip@b998138d3ab8ca0ea212c00469042349f8c3fe53, we introduce a check for responses from outgoing webhooks that require them to be a dictionary. This fixes the return value of the botserver view function to accommodate with the change from the serverside.