### PR TITLE
botserver: Fix mypy error.

### DIFF
--- a/zulip_botserver/zulip_botserver/server.py
+++ b/zulip_botserver/zulip_botserver/server.py
@@ -169,6 +169,7 @@ bots_config = {}  # type: Dict[str, Dict[str, str]]
 @app.route('/', methods=['POST'])
 def handle_bot() -> str:
     event = request.get_json(force=True)
+    assert event is not None
     for bot_name, config in bots_config.items():
         if config['email'] == event['bot_email']:
             bot = bot_name


### PR DESCRIPTION
Value of type "Optional[Any]" is not indexable error was originated by mypy.
```
zulip_botserver/zulip_botserver/server.py:172: error: Value of type "Optional[Any]" is not indexable
zulip_botserver/zulip_botserver/server.py:179: error: Value of type "Optional[Any]" is not indexable
zulip_botserver/zulip_botserver/server.py:180: error: Value of type "Optional[Any]" is not indexable
zulip_botserver/zulip_botserver/server.py:183: error: Value of type "Optional[Any]" is not indexable
zulip_botserver/zulip_botserver/server.py:187: error: Value of type "Optional[Any]" is not indexable
zulip_botserver/zulip_botserver/server.py:188: error: Value of type "Optional[Any]" is not indexable
zulip_botserver/zulip_botserver/server.py:189: error: Value of type "Optional[Any]" is not indexable
```
and 
```
zulip_botserver/zulip_botserver/server.py:173: error: Value of type "Optional[Any]" is not indexable
zulip_botserver/zulip_botserver/server.py:180: error: Value of type "Optional[Any]" is not indexable
zulip_botserver/zulip_botserver/server.py:181: error: Value of type "Optional[Any]" is not indexable
zulip_botserver/zulip_botserver/server.py:184: error: Value of type "Optional[Any]" is not indexable
zulip_botserver/zulip_botserver/server.py:188: error: Value of type "Optional[Any]" is not indexable
zulip_botserver/zulip_botserver/server.py:189: error: Value of type "Optional[Any]" is not indexable
zulip_botserver/zulip_botserver/server.py:190: error: Value of type "Optional[Any]" is not indexable
```
was originated in PR #682.