### PR TITLE
Implement context manager for bot storage

### DIFF
--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -67,6 +67,21 @@ class RateLimit:
         logging.error(self.error_message)
         sys.exit(1)
 
+class BotIdentity:
+    def __init__(self, name: str, email: str) -> None:
+        self.name = name
+        self.email = email
+        self.mention = '@**' + name + '**'
+
+class BotStorage(Protocol):
+    def put(self, key: Text, value: Any) -> None:
+        ...
+
+    def get(self, key: Text) -> Any:
+        ...
+
+    def contains(self, key: Text) -> bool:
+        ...
 
 class StateHandler:
     def __init__(self, client: Client) -> None:
@@ -96,21 +111,6 @@ class StateHandler:
     def contains(self, key: Text) -> bool:
         return key in self.state_
 
-class BotIdentity:
-    def __init__(self, name: str, email: str) -> None:
-        self.name = name
-        self.email = email
-        self.mention = '@**' + name + '**'
-
-class BotStorage(Protocol):
-    def put(self, key: Text, value: Any) -> None:
-        ...
-
-    def get(self, key: Text) -> Any:
-        ...
-
-    def contains(self, key: Text) -> bool:
-        ...
 
 class BotHandler(Protocol):
 


### PR DESCRIPTION
The context manager is implemented based on a newly added storage calledCachedStorage. It is buffered storage that doesn't sync with the database until it's flushed. With CachedStorage, we can implement the context manager easily by loading all the data on __enter__ and just flush all the modified (dirty) data on __exit__. This approach can help the user minimize the number of round-trips to the server almost invisibly (despite the fact that they need to use it with "with").

https://zulip.com/api/writing-bots#bot_handlerstorage

Manually tested with the incrementor bot.

Possible upcoming work: adding documentation and tests

#679