### PR TITLE
zulip-bots: Yield cache storage instead bot storage.

### DIFF
--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -164,7 +164,7 @@ def use_storage(storage: BotStorage, keys: List[Text]) -> Iterator[BotStorage]:
     # calling flush or getting some values that are not previously fetched.
     data = {key: storage.get(key) for key in keys}
     cache = CachedStorage(storage, data)
-    yield storage
+    yield cache
     cache.flush()
 
 class BotHandler(Protocol):


### PR DESCRIPTION
Fixes the bug that the context manager doesn't actually return the cache storage due to a typo.