### PR TITLE
matrix: fix bounce-back when bot not on matrix.org

### DIFF
--- a/zulip/integrations/bridge_with_matrix/matrix_bridge.py
+++ b/zulip/integrations/bridge_with_matrix/matrix_bridge.py
@@ -77,7 +77,7 @@ def matrix_to_zulip(
         """
         content = get_message_content_from_event(event, no_noise)
 
-        zulip_bot_user = "@{}:matrix.org".format(matrix_config["username"])
+        zulip_bot_user = "{}".format(matrix_config["username"])
         # We do this to identify the messages generated from Zulip -> Matrix
         # and we make sure we don't forward it again to the Zulip stream.
         not_from_zulip_bot = event["sender"] != zulip_bot_user


### PR DESCRIPTION
this requires having the matrix name properly set in matrix_bridge.conf (e.g. @zulip-bot:myhomserver.com)