### PR TITLE
matrix: Fix test failure brought by the hint for usernames change.

### DIFF
--- a/zulip/integrations/bridge_with_matrix/test_matrix.py
+++ b/zulip/integrations/bridge_with_matrix/test_matrix.py
@@ -17,7 +17,7 @@ sample_config_path = "matrix_test.conf"
 
 sample_config_text = """[matrix]
 host = https://matrix.org
-username = username
+username = @username@matrix.org
 password = password
 room_id = #zulip:matrix.org
 


### PR DESCRIPTION
Fixes a188a4e72a525847ded80eee6e864e43715e3bd7.