### PR TITLE
zulibot-action: Add commands-action.

### DIFF
--- a/.github/workflows/commands-action.yml
+++ b/.github/workflows/commands-action.yml
@@ -1,0 +1,18 @@
+name: Commands Action
+
+on:
+  # Run the action whenever a comment is added on an issue or PR.
+  # (`issue_comment` event is triggered on PR comments as well.)
+  issue_comment:
+    types: created
+
+jobs:
+  commands-action:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Handle commands
+        uses: garg3133/zulipbot-action/commands-action@main
+        with:
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
+          # Relative path to the commands-action config file.
+          config-file-path: .github/zulipbot-config/commands-action.yml

--- a/.github/zulipbot-config/commands-action.yml
+++ b/.github/zulipbot-config/commands-action.yml
@@ -1,0 +1,35 @@
+# Enable @claim and @abandon issue commands.
+assign:
+  # Maximum users who can claim a single issue.
+  max_assignees: 1
+
+  # Whether or not to invite the contributors claiming an issue
+  # for the first time on your repository, as a collaborator
+  # with the "pull" (read) permission on you repository, before
+  # assigning them the issue.
+  add_as_collaborator: true
+
+  # Restrictions on the new contributors.
+  new_contributors:
+    # Maximum issues a new contributor can claim at the same
+    # time.
+    max_issue_claims: 1
+
+    # Allow the new contributors to claim an issue only if it
+    # contains/does no contain certain labels.
+    assign_only_if:
+      any_label_present: ["good first issue", "help wanted"]
+
+# Enable @add and @remove label commands.
+label:
+  # @keywords:
+  #   "all": All authenticated users on GitHub.
+  #   "author": Author of issue or pull request.
+  #   "member": Member of the organization containing the
+  #            repository.
+  #   "@username": Specific GitHub user.
+
+  # Users given full_permission can add or remove any labels on
+  # issues and pull requests.
+  full_permission:
+    to: ["author"]


### PR DESCRIPTION
This PR adds the newly built Zulipbot commands-action to this repository.

**Notes**
For this action to work, the maintainers need to follow three additional steps:
* Get the Personal access token for Zulipbot's GitHub account (See the second paragraph of https://github.com/garg3133/zulipbot-action/tree/main/commands-action#create-a-github-account-for-the-bot).
* Add Zulipbot as a collaborator on this repository with admin access(if this isn't already the case).
* Save the Personal access token of Zulipbot as a secret on this repository, with the name `BOT_ACCESS_TOKEN`. (See https://github.com/garg3133/zulipbot-action/tree/main/commands-action#configure-bots-access-to-your-repository)


On a side note, I've set the current configuration of this action to match with the original Zulipbot configuration. So, do let me know if you need any changes in the configuration of this action. See the complete configuration of this action at https://github.com/garg3133/zulipbot-action/blob/main/commands-action/config/sample-config.yml.

This action covers only the `@zulipbot claim/abandon/add/remove` functionalities.
