### PR TITLE
zephyr_mirror_backend: Add missing parens for calling lower()

### DIFF
--- a/zulip/integrations/zephyr/zephyr_mirror_backend.py
+++ b/zulip/integrations/zephyr/zephyr_mirror_backend.py
@@ -475,7 +475,7 @@ def process_notice(notice: "zephyr.ZNotice", log: Optional[IO[str]]) -> None:
 
     # Add instances in for instanced personals
     if is_personal:
-        if notice.cls.lower() != "message" and notice.instance.lower != "personal":
+        if notice.cls.lower() != "message" and notice.instance.lower() != "personal":
             heading = f"[-c {notice.cls} -i {notice.instance}]\n"
         elif notice.cls.lower() != "message":
             heading = f"[-c {notice.cls}]\n"


### PR DESCRIPTION
Found by trying to enable mypy `strict_equality`. @timabbott FYI.