### PR TITLE
git: Fix git_repository_name

### DIFF
--- a/zulip/integrations/git/post-receive
+++ b/zulip/integrations/git/post-receive
@@ -33,11 +33,10 @@ client = zulip.Client(
 
 
 def git_repository_name() -> str:
-    output = subprocess.check_output(["git", "rev-parse", "--is-bare-repository"])
-    if output.strip() == "true":
-        return os.path.basename(os.getcwd())[: -len(".git")]
-    else:
-        return os.path.basename(os.path.dirname(os.getcwd()))
+    path, name = os.path.split(os.getcwd())
+    if name == ".git":
+        name = os.path.basename(path)
+    return name[: -len(".git")] if name.endswith(".git") else name
 
 
 def git_commit_range(oldrev: str, newrev: str) -> str:


### PR DESCRIPTION
Without `universal_newlines=True` or `text=True`, `subprocess.check_output` returns `bytes`, not `str`, so it makes no sense to compare its return to `"true"`. But upstream Git’s behavior only depends on the filename, not whether the repository is bare; emulate this more closely.