### PR TITLE
Slack bridge: Explicitly require aiohttp.

### DIFF
--- a/zulip/integrations/bridge_with_slack/requirements.txt
+++ b/zulip/integrations/bridge_with_slack/requirements.txt
@@ -1,1 +1,2 @@
 slack-sdk==3.5.1
+aiohttp


### PR DESCRIPTION
It is required by the Slack library, but strangely not installed. So we
explicitly specify it.