### PR TITLE
zulip: Reraise exceptions in do_api_query. 

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -10,7 +10,7 @@ import time
 import traceback
 import types
 import urllib.parse
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 from typing import (
     IO,
     Any,
@@ -425,9 +425,9 @@ class Client:
             config_file = get_default_config_filename()
 
         if config_file is not None and os.path.exists(config_file):
-            config = SafeConfigParser()
+            config = ConfigParser()
             with open(config_file) as f:
-                config.readfp(f, config_file)
+                config.read_file(f, config_file)
             if api_key is None:
                 api_key = config.get("api", "key")
             if email is None:


### PR DESCRIPTION
There are cases where the call to get_server_settings returns a JSON response with a connection error. In the case of such an unsuccessful response, we should raise an appropriate exception instead of parsing the response as though it was successful.

@timabbott Could you please take a look at this? Not sure if this is the right fix. Also, wondering if I should put a test for this somewhere in `zulip_botserver`?