### PR TITLE
bots: Migrate script name from zulip-terminal to zulip-bot-shell.

### DIFF
--- a/zulip_bots/setup.py
+++ b/zulip_bots/setup.py
@@ -52,7 +52,7 @@ package_info = dict(
     entry_points={
         "console_scripts": [
             "zulip-run-bot=zulip_bots.run:main",
-            "zulip-terminal=zulip_bots.terminal:main",
+            "zulip-bot-shell=zulip_bots.terminal:main",
         ],
     },
 )  # type: Dict[str, Any]


### PR DESCRIPTION
This change is intended to reduce confusion between zulip-bot-shell
(test bots interactively without a server) and the zulip/zulip-terminal
project and its associated command (zulip-term).

Latest reference at https://chat.zulip.org/#narrow/stream/127-integrations/topic/Migrating.20bot.20zulip-terminal.20script

Docs change in main repo at zulip/zulip#20310