### PR TITLE
api: Add subset of Literal types used in zulip-terminal

### DIFF
--- a/zulip/setup.py
+++ b/zulip/setup.py
@@ -71,6 +71,7 @@ setuptools_info = dict(
         "matrix_client",
         "distro",
         "click",
+        "typing_extensions>=3.7",
     ],
 )
 


### PR DESCRIPTION
See https://chat.zulip.org/#narrow/stream/378-api-design/topic/python.20bindings.20and.20constants

The first commit is useful as it integrates with the API directly; the second doesn't integrate with the API as the method parameter data types are unspecified dicts right now (see discussion).