### PR TITLE
tools/provision: Bump required pip version from >=9.0 to >=10.

### DIFF
--- a/tools/provision
+++ b/tools/provision
@@ -97,7 +97,7 @@ the Python version this command is executed with."""
     def install_dependencies(requirements_filename):
         pip_path = os.path.join(venv_dir, venv_exec_dir, "pip")
         # We first install a modern version of pip that supports --prefix
-        subprocess.call([pip_path, "install", "pip>=9.0"])
+        subprocess.call([pip_path, "install", "pip>=10"])
         if subprocess.call(
             [
                 pip_path,


### PR DESCRIPTION
The version of pip that comes bundled with venv is often outdated, which can lead to unexpected errors when installing dependencies. This commit ensures that pip is upgraded to the latest version before any dependencies are installed.

This commit fixes an issue I discovered in my WSL2 development environment. Before this commit, running `python3 tools/provision` resulted in the following exception:

``` 
Collecting cryptography>=2.0 (from SecretStorage>=3.2; sys_platform == "linux"->keyring>=15.1->twine->-r /home/eeshangarg/python-zulip-api/requirements.txt (line 2))
  Cache entry deserialization failed, entry ignored
  Using cached https://files.pythonhosted.org/packages/f9/4b/1cf8e281f7ae4046a59e5e39dd7471d46db9f61bb564fddbff9084c4334f/cryptography-36.0.1.tar.gz
    Complete output from command python setup.py egg_info:

            =============================DEBUG ASSISTANCE==========================
            If you are seeing an error here please try the following to
            successfully install cryptography:

            Upgrade to the latest pip and try again. This will fix errors for most
            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
            =============================DEBUG ASSISTANCE==========================

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-4uv114nu/cryptography/setup.py", line 14, in <module>
        from setuptools_rust import RustExtension
    ModuleNotFoundError: No module named 'setuptools_rust'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-4uv114nu/cryptography/
Traceback (most recent call last):
  File "tools/provision", line 141, in <module>
    main()
  File "tools/provision", line 117, in main
    install_dependencies("requirements.txt")
  File "tools/provision", line 113, in install_dependencies
    os.path.join(base_dir, requirements_filename)
OSError: The command `pip install -r /home/eeshangarg/python-zulip-api/requirements.txt` failed. Dependencies not installed!
```

After some investigation, I discovered that the `pip` was not being upgraded properly. 

@andersk Could you please review this?