### PR TITLE
zulip: Fix principals default for remove_subscriptions

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -1383,12 +1383,16 @@ class Client:
         )
 
     def remove_subscriptions(
-        self, streams: Iterable[str], principals: Union[Sequence[str], Sequence[int]] = []
+        self,
+        streams: Iterable[str],
+        principals: Optional[Union[Sequence[str], Sequence[int]]] = None,
     ) -> Dict[str, Any]:
         """
         See examples/unsubscribe for example usage.
         """
-        request = dict(subscriptions=streams, principals=principals)
+        request: Dict[str, object] = dict(subscriptions=streams)
+        if principals is not None:
+            request["principals"] = principals
         return self.call_endpoint(
             url="users/me/subscriptions",
             method="DELETE",


### PR DESCRIPTION
The documented API for `DELETE /api/v1/users/me/subscriptions` is that `principals` should be omitted to remove a subscription for the calling user.  A call with `principals=[]` should have a different meaning, but a server bug currently conflates this with a call omitting `principals`. Avoid relying on this bug.