### PR TITLE
Cert Bundle might also be a directory

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -489,7 +489,7 @@ class Client:
             )
             self.tls_verification = False  # type: Union[bool, str]
         elif cert_bundle is not None:
-            if not os.path.isfile(cert_bundle):
+            if not os.path.exists(cert_bundle):
                 raise ConfigNotFoundError(f"tls bundle '{cert_bundle}' does not exist")
             self.tls_verification = cert_bundle
         else:


### PR DESCRIPTION
So I changed the cert bundle verification to also support supplying other paths to the requests API by using `exists` instead of `isfile`. Now for me the zulip API works again.