### PR TITLE
bridge_with_matrix: Bump matrix-client 0.2.0 -> 0.4.0.

### DIFF
--- a/zulip/integrations/bridge_with_matrix/requirements.txt
+++ b/zulip/integrations/bridge_with_matrix/requirements.txt
@@ -1,1 +1,1 @@
-matrix-client==0.2.0
+matrix-client==0.4.0


### PR DESCRIPTION
This fixes #754.