### PR TITLE
Matrix bridge: Print reminder to subscribe the bots on startup.

### DIFF
--- a/zulip/integrations/bridge_with_matrix/matrix_bridge.py
+++ b/zulip/integrations/bridge_with_matrix/matrix_bridge.py
@@ -317,6 +317,11 @@ def main() -> None:
     zulip_config = config["zulip"]
     matrix_config = config["matrix"]
 
+    print(
+        "IMPORTANT: Make sure that the bot accounts have been"
+        " subscribed to the relevant Matrix room / Zulip stream"
+    )
+
     # Initiate clients
     backoff = zulip.RandomExponentialBackoff(timeout_success_equivalent=300)
     while backoff.keep_going():


### PR DESCRIPTION
This problem has happened far too frequently. See e.g. https://chat.zulip.org/#narrow/stream/9-issues/topic/.E2.9C.94.20Matrix.20Zulip.20integration.20error/near/1388040.