### PR TITLE
zephyr: Fix thread safety; remove python-zephyr in favor of ctypes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,12 @@ line-length = 100
 target-version = ["py36"]
 
 [tool.isort]
-src_paths = ["tools", "zulip", "zulip_bots", "zulip_botserver"]
+src_paths = [
+    "tools",
+    "zulip",
+    "zulip/integrations/zephyr",
+    "zulip_bots",
+    "zulip_botserver",
+]
 profile = "black"
 line_length = 100

--- a/zulip/integrations/zephyr/check-mirroring
+++ b/zulip/integrations/zephyr/check-mirroring
@@ -6,10 +6,10 @@ import random
 import subprocess
 import sys
 import time
+from ctypes import byref, c_int, c_ushort
 from typing import Dict, List, Set, Tuple
 
-import zephyr
-
+import zephyr_ctypes
 import zulip
 
 parser = optparse.OptionParser()
@@ -136,9 +136,43 @@ for (stream, test) in test_streams:
 actually_subscribed = False
 for tries in range(10):
     try:
-        zephyr.init()
-        zephyr._z.subAll(zephyr_subs_to_add)
-        zephyr_subs = zephyr._z.getSubscriptions()
+        zephyr_ctypes.check(zephyr_ctypes.ZInitialize())
+        zephyr_port = c_ushort()
+        zephyr_ctypes.check(zephyr_ctypes.ZOpenPort(byref(zephyr_port)))
+        zephyr_ctypes.check(zephyr_ctypes.ZCancelSubscriptions(0))
+
+        zephyr_ctypes.check(
+            zephyr_ctypes.ZSubscribeTo(
+                (zephyr_ctypes.ZSubscription_t * len(zephyr_subs_to_add))(
+                    *(
+                        zephyr_ctypes.ZSubscription_t(
+                            zsub_class=cls.encode(),
+                            zsub_classinst=instance.encode(),
+                            zsub_recipient=recipient.encode(),
+                        )
+                        for cls, instance, recipient in zephyr_subs_to_add
+                    )
+                ),
+                len(zephyr_subs_to_add),
+                0,
+            )
+        )
+
+        try:
+            nsubs = c_int()
+            zephyr_ctypes.check(zephyr_ctypes.ZRetrieveSubscriptions(0, byref(nsubs)))
+            zsubs = (zephyr_ctypes.ZSubscription_t * nsubs.value)()
+            zephyr_ctypes.check(zephyr_ctypes.ZGetSubscriptions(zsubs, byref(nsubs)))
+            zephyr_subs = {
+                (
+                    zsub.zsub_class.decode(),
+                    zsub.zsub_classinst.decode(),
+                    zsub.zsub_recipient.decode(),
+                )
+                for zsub in zsubs
+            }
+        finally:
+            zephyr_ctypes.ZFlushSubscriptions()
 
         missing = 0
         for elt in zephyr_subs_to_add:
@@ -148,8 +182,8 @@ for tries in range(10):
         if missing == 0:
             actually_subscribed = True
             break
-    except OSError as e:
-        if "SERVNAK received" in e.args:
+    except zephyr_ctypes.ZephyrError as e:
+        if e.code == zephyr_ctypes.ZERR_SERVNAK:
             logger.error("SERVNAK repeatedly received, punting rest of test")
         else:
             logger.exception("Exception subscribing to zephyrs")
@@ -185,15 +219,15 @@ notices = []
 # receive queue with 30+ messages, which might result in messages
 # being dropped.
 def receive_zephyrs() -> None:
-    while True:
+    while zephyr_ctypes.ZPending() != 0:
+        notice = zephyr_ctypes.ZNotice_t()
+        sender = zephyr_ctypes.sockaddr_in()
         try:
-            notice = zephyr.receive(block=False)
-        except Exception:
+            zephyr_ctypes.check(zephyr_ctypes.ZReceiveNotice(byref(notice), byref(sender)))
+        except zephyr_ctypes.ZephyrError:
             logging.exception("Exception receiving zephyrs:")
-            notice = None
-        if notice is None:
             break
-        if notice.opcode != "":
+        if notice.z_opcode != b"":
             continue
         notices.append(notice)
 
@@ -294,7 +328,10 @@ def process_keys(content_list: List[str]) -> Tuple[Dict[str, int], Set[str], Set
 # The h_foo variables are about the messages we _received_ in Zulip
 # The z_foo variables are about the messages we _received_ in Zephyr
 h_contents = [message["content"] for message in messages]
-z_contents = [notice.message.split("\0")[1] for notice in notices]
+z_contents = [
+    notice.z_message[: notice.z_message_len].split(b"\0")[1].decode(errors="replace")
+    for notice in notices
+]
 (h_key_counts, h_missing_z, h_missing_h, h_duplicates, h_success) = process_keys(h_contents)
 (z_key_counts, z_missing_z, z_missing_h, z_duplicates, z_success) = process_keys(z_contents)
 

--- a/zulip/integrations/zephyr/process_ccache
+++ b/zulip/integrations/zephyr/process_ccache
@@ -18,7 +18,7 @@ api_key_path = f"/home/zulip/api-keys/{program_name}"
 open(api_key_path, "w").write(api_key + "\n")
 
 # Setup supervisord configuration
-supervisor_path = f"/etc/supervisor/conf.d/zulip/{program_name}.conf"
+supervisor_path = f"/etc/supervisor/conf.d/zmirror/{program_name}.conf"
 template = os.path.join(os.path.dirname(__file__), "zmirror_private.conf.template")
 template_data = open(template).read()
 session_path = f"/home/zulip/zephyr_sessions/{program_name}"

--- a/zulip/integrations/zephyr/zephyr_ctypes.py
+++ b/zulip/integrations/zephyr/zephyr_ctypes.py
@@ -1,0 +1,206 @@
+from ctypes import (
+    CDLL,
+    CFUNCTYPE,
+    POINTER,
+    Structure,
+    Union,
+    c_char,
+    c_char_p,
+    c_int,
+    c_long,
+    c_uint,
+    c_uint8,
+    c_uint16,
+    c_uint32,
+    c_ushort,
+    c_void_p,
+)
+
+libc = CDLL("libc.so.6")
+com_err = CDLL("libcom_err.so.2")
+libzephyr = CDLL("libzephyr.so.4")
+
+
+# --- glibc/bits/sockaddr.h ---
+
+sa_family_t = c_ushort
+
+
+# --- glibc/sysdeps/unix/sysv/linux/bits/socket.h ---
+
+
+class sockaddr(Structure):
+    _fields_ = [
+        ("sa_family", sa_family_t),
+        ("sa_data", c_char * 14),
+    ]
+
+
+# --- glibc/inet/netinet/in.h ---
+
+in_port_t = c_uint16
+in_addr_t = c_uint32
+
+
+class in_addr(Structure):
+    _fields_ = [
+        ("s_addr", in_addr_t),
+    ]
+
+
+class sockaddr_in(Structure):
+    _fields_ = [
+        ("sin_family", sa_family_t),
+        ("sin_port", in_port_t),
+        ("sin_addr", in_addr),
+        ("sin_zero", c_uint8 * 8),
+    ]
+
+
+class in6_addr(Structure):
+    _fields_ = [
+        ("s6_addr", c_uint8 * 16),
+    ]
+
+
+class sockaddr_in6(Structure):
+    _fields_ = [
+        ("sin6_family", sa_family_t),
+        ("sin6_port", in_port_t),
+        ("sin6_flowinfo", c_uint32),
+        ("sin6_addr", in6_addr),
+        ("sin6_scope_id", c_uint32),
+    ]
+
+
+# --- glibc/stdlib/stdlib.h ---
+
+free = CFUNCTYPE(None, c_void_p)(("free", libc))
+
+
+# --- e2fsprogs/lib/et/com_err.h ---
+
+error_message = CFUNCTYPE(c_char_p, c_long)(("error_message", com_err))
+
+
+# --- zephyr/h/zephyr/zephyr.h ---
+
+Z_MAXOTHERFIELDS = 10
+
+ZNotice_Kind_t = c_int
+
+
+class _ZTimeval(Structure):
+    _fields_ = [
+        ("tv_sec", c_int),
+        ("tv_usec", c_int),
+    ]
+
+
+class ZUnique_Id_t(Structure):
+    _fields_ = [
+        ("zuid_addr", in_addr),
+        ("tv", _ZTimeval),
+    ]
+
+
+ZChecksum_t = c_uint
+
+
+class _ZSenderSockaddr(Union):
+    _fields_ = [
+        ("sa", sockaddr),
+        ("ip4", sockaddr_in),
+        ("ip6", sockaddr_in6),
+    ]
+
+
+class ZNotice_t(Structure):
+    _fields_ = [
+        ("z_packet", c_char_p),
+        ("z_version", c_char_p),
+        ("z_kind", ZNotice_Kind_t),
+        ("z_uid", ZUnique_Id_t),
+        ("z_sender_sockaddr", _ZSenderSockaddr),
+        ("z_time", _ZTimeval),
+        ("z_port", c_ushort),
+        ("z_charset", c_ushort),
+        ("z_auth", c_int),
+        ("z_checked_auth", c_int),
+        ("z_authent_len", c_int),
+        ("z_ascii_authent", c_char_p),
+        ("z_class", c_char_p),
+        ("z_class_inst", c_char_p),
+        ("z_opcode", c_char_p),
+        ("z_sender", c_char_p),
+        ("z_recipient", c_char_p),
+        ("z_default_format", c_char_p),
+        ("z_multinotice", c_char_p),
+        ("z_multiuid", ZUnique_Id_t),
+        ("z_checksum", ZChecksum_t),
+        ("z_ascii_checksum", c_char_p),
+        ("z_num_other_fields", c_int),
+        ("z_other_fields", c_char_p * Z_MAXOTHERFIELDS),
+        ("z_message", POINTER(c_char)),
+        ("z_message_len", c_int),
+        ("z_num_hdr_fields", c_uint),
+        ("z_hdr_fields", POINTER(c_char_p)),
+    ]
+
+
+class ZSubscription_t(Structure):
+    _fields_ = [
+        ("zsub_recipient", c_char_p),
+        ("zsub_class", c_char_p),
+        ("zsub_classinst", c_char_p),
+    ]
+
+
+Code_t = c_int
+
+ZInitialize = CFUNCTYPE(Code_t)(("ZInitialize", libzephyr))
+ZRetrieveSubscriptions = CFUNCTYPE(Code_t, c_ushort, POINTER(c_int))(
+    ("ZRetrieveSubscriptions", libzephyr)
+)
+ZGetSubscriptions = CFUNCTYPE(Code_t, POINTER(ZSubscription_t), POINTER(c_int))(
+    ("ZGetSubscriptions", libzephyr)
+)
+ZOpenPort = CFUNCTYPE(Code_t, POINTER(c_ushort))(("ZOpenPort", libzephyr))
+ZFlushSubscriptions = CFUNCTYPE(Code_t)(("ZFlushSubscriptions", libzephyr))
+ZSubscribeTo = CFUNCTYPE(Code_t, POINTER(ZSubscription_t), c_int, c_uint)(
+    ("ZSubscribeTo", libzephyr)
+)
+ZCancelSubscriptions = CFUNCTYPE(Code_t, c_uint)(("ZCancelSubscriptions", libzephyr))
+ZPending = CFUNCTYPE(c_int)(("ZPending", libzephyr))
+ZReceiveNotice = CFUNCTYPE(Code_t, POINTER(ZNotice_t), POINTER(sockaddr_in))(
+    ("ZReceiveNotice", libzephyr)
+)
+ZDumpSession = CFUNCTYPE(Code_t, POINTER(POINTER(c_char)), POINTER(c_int))(
+    ("ZDumpSession", libzephyr)
+)
+ZLoadSession = CFUNCTYPE(Code_t, POINTER(c_char), c_int)(("ZLoadSession", libzephyr))
+ZGetFD = CFUNCTYPE(c_int)(("ZGetFD", libzephyr))
+
+ZERR_NONE = 0
+
+
+# --- zephyr/lib/zephyr_err.et ---
+
+ERROR_TABLE_BASE_zeph = -772103680
+ZERR_SERVNAK = ERROR_TABLE_BASE_zeph + 16
+
+
+# --- convenience helpers ---
+
+
+class ZephyrError(Exception):
+    def __init__(self, code: int) -> None:
+        self.code = code
+
+    def __str__(self) -> str:
+        return error_message(self.code).decode()
+
+
+def check(code: int) -> None:
+    if code != ZERR_NONE:
+        raise ZephyrError(code)


### PR DESCRIPTION
Our custom patched version of python-zephyr only worked on Python 2. Now we don’t need python-zephyr at all.

Tested `zephyr_mirror.py` with personals in both directions on an Athena dialup.