### PR TITLE
fixes #637: add remove_storage helper

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -1652,6 +1652,22 @@ class Client:
             request=request,
         )
 
+    def remove_storage(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Example usage:
+
+        >>> client.remove_storage({'keys': ["entry 1", "entry 3"]})
+        >>> client.get_storage({'keys': ["entry 1", "entry 3"]})
+
+            raise KeyError("Key not found" + key)
+            KeyError: 'Key not found'
+        """
+        return self.call_endpoint(
+            url="bot_storage",
+            method="DELETE",
+            request=request,
+        )
+
     def set_typing_status(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """
         Example usage:

--- a/zulip_bots/zulip_bots/tests/test_lib.py
+++ b/zulip_bots/zulip_bots/tests/test_lib.py
@@ -37,6 +37,11 @@ class FakeClient:
             storage=self.storage,
         )
 
+    def remove_storage(self, payload):
+        for item in payload["keys"]:
+            self.storage.pop(item)
+        return dict(result="success")
+
     def send_message(self, message):
         return dict(
             result="success",


### PR DESCRIPTION
Fixes: #637

Added `remove_storage` helper along with following tasks:

- [x] Test unit for remove_storage
- [x] Function Docstring for easy usage


**Now, method of deleting the `storage` records:**

```python
 client.remove_storage({'keys': ["entry 1", "entry 3"]})
```

> **Successful deletion returns** 

```json
{ "result":"success"}
```