### PR TITLE
matrix bridge: Improve mime-type detection.

### DIFF
--- a/zulip/integrations/bridge_with_matrix/requirements.txt
+++ b/zulip/integrations/bridge_with_matrix/requirements.txt
@@ -1,3 +1,1 @@
 matrix-nio
-python-magic
-python-magic-bin; platform_system == "Windows"


### PR DESCRIPTION
Hi :) This PR lets the matrix bridge handle mime-types of files without the `python-magic` library by using the response object of the HTTP request.
See [here](https://chat.zulip.org/#narrow/stream/127-integrations/topic/Matrix.20.3C-.3E.20Zulip.20Bridge/near/1432848) for the discussion.
Please review :)