### PR TITLE
Fix recent linter errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 crayons
 twine
-black
+black==23.3.0
 isort
 flake8
 mock

--- a/zulip/integrations/git/zulip_git_config.py
+++ b/zulip/integrations/git/zulip_git_config.py
@@ -8,6 +8,7 @@ STREAM_NAME = "commits"
 ZULIP_USER = "git-bot@example.com"
 ZULIP_API_KEY = "0123456789abcdef0123456789abcdef"
 
+
 # commit_notice_destination() lets you customize where commit notices
 # are sent to with the full power of a Python function.
 #

--- a/zulip/integrations/openshift/zulip_openshift_config.py
+++ b/zulip/integrations/openshift/zulip_openshift_config.py
@@ -5,6 +5,7 @@ from typing import Dict, Optional
 ZULIP_USER = "openshift-bot@example.com"
 ZULIP_API_KEY = "0123456789abcdef0123456789abcdef"
 
+
 # deployment_notice_destination() lets you customize where deployment notices
 # are sent to with the full power of a Python function.
 #

--- a/zulip/integrations/perforce/zulip_perforce_config.py
+++ b/zulip/integrations/perforce/zulip_perforce_config.py
@@ -14,6 +14,7 @@ ZULIP_IGNORE_MISSING_STREAM = False
 # P4_WEB = "https://p4web.example.com"
 P4_WEB: Optional[str] = None
 
+
 # commit_notice_destination() lets you customize where commit notices
 # are sent to with the full power of a Python function.
 #

--- a/zulip/integrations/svn/zulip_svn_config.py
+++ b/zulip/integrations/svn/zulip_svn_config.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional
 ZULIP_USER = "svn-bot@example.com"
 ZULIP_API_KEY = "0123456789abcdef0123456789abcdef"
 
+
 # commit_notice_destination() lets you customize where commit notices
 # are sent to with the full power of a Python function.
 #

--- a/zulip/integrations/zephyr/check-mirroring
+++ b/zulip/integrations/zephyr/check-mirroring
@@ -61,7 +61,7 @@ if options.sharded:
         ("tabbott-nagios-test-11", "e"),
         ("tabbott-nagios-test-9", "f"),
     ]
-    for (stream, test) in test_streams:
+    for stream, test in test_streams:
         if stream == "message":
             continue
         assert hashlib.sha1(stream.encode("utf-8")).hexdigest().startswith(test)
@@ -73,7 +73,6 @@ else:
 
 
 def print_status_and_exit(status: int) -> None:
-
     # The output of this script is used by Nagios. Various outputs,
     # e.g. true success and punting due to a SERVNAK, result in a
     # non-alert case, so to give us something unambiguous to check in
@@ -127,7 +126,7 @@ except Exception:
 
 # Subscribe to Zephyrs
 zephyr_subs_to_add = []
-for (stream, test) in test_streams:
+for stream, test in test_streams:
     if stream == "message":
         zephyr_subs_to_add.append((stream, "personal", mit_user))
     else:
@@ -206,7 +205,7 @@ def gen_key(key_dict: Dict[str, Tuple[str, str]]) -> str:
 
 
 def gen_keys(key_dict: Dict[str, Tuple[str, str]]) -> None:
-    for (stream, test) in test_streams:
+    for stream, test in test_streams:
         key_dict[gen_key(key_dict)] = (stream, test)
 
 
@@ -214,6 +213,7 @@ gen_keys(zhkeys)
 gen_keys(hzkeys)
 
 notices = []
+
 
 # We check for new zephyrs multiple times, to avoid filling the zephyr
 # receive queue with 30+ messages, which might result in messages
@@ -310,7 +310,6 @@ all_keys = set(list(zhkeys.keys()) + list(hzkeys.keys()))
 
 
 def process_keys(content_list: List[str]) -> Tuple[Dict[str, int], Set[str], Set[str], bool, bool]:
-
     # Start by filtering out any keys that might have come from
     # concurrent check-mirroring processes
     content_keys = [key for key in content_list if key in all_keys]

--- a/zulip/integrations/zephyr/zephyr_mirror.py
+++ b/zulip/integrations/zephyr/zephyr_mirror.py
@@ -16,7 +16,6 @@ from types import FrameType
 
 
 def die(signal: int, frame: FrameType) -> None:
-
     # We actually want to exit, so run os._exit (so as not to be caught and restarted)
     os._exit(1)
 

--- a/zulip/integrations/zephyr/zephyr_mirror.py
+++ b/zulip/integrations/zephyr/zephyr_mirror.py
@@ -43,7 +43,7 @@ if options.forward_class_messages and not options.noshard:
         process = await asyncio.create_subprocess_exec(*args, f"--shard={shard}")
         return await process.wait()
 
-    async def run_shards():
+    async def run_shards() -> None:
         for coro in asyncio.as_completed(map(run_shard, shards)):
             await coro
             print("A mirroring shard died!")

--- a/zulip/integrations/zephyr/zephyr_mirror_backend.py
+++ b/zulip/integrations/zephyr/zephyr_mirror_backend.py
@@ -222,7 +222,7 @@ def zephyr_bulk_subscribe(subs: List[Tuple[str, str, str]]) -> None:
     finally:
         zephyr_ctypes.ZFlushSubscriptions()
 
-    for (cls, instance, recipient) in subs:
+    for cls, instance, recipient in subs:
         if cls not in actual_zephyr_subs:
             logger.error(f"Zephyr failed to subscribe us to {cls}; will retry")
             # We'll retry automatically when we next check for
@@ -968,7 +968,7 @@ def subscribed_to_mail_messages() -> bool:
     stored_result = os.environ.get("HUMBUG_FORWARD_MAIL_ZEPHYRS")
     if stored_result is not None:
         return stored_result == "True"
-    for (cls, instance, recipient) in parse_zephyr_subs(verbose=False):
+    for cls, instance, recipient in parse_zephyr_subs(verbose=False):
         if cls.lower() == "mail" and instance.lower() == "inbox":
             os.environ["HUMBUG_FORWARD_MAIL_ZEPHYRS"] = "True"
             return True
@@ -981,7 +981,7 @@ def add_zulip_subscriptions(verbose: bool) -> None:
 
     zephyr_subscriptions = set()
     skipped = set()
-    for (cls, instance, recipient) in parse_zephyr_subs(verbose=verbose):
+    for cls, instance, recipient in parse_zephyr_subs(verbose=verbose):
         if cls.lower() == "message":
             if recipient != "*":
                 # We already have a (message, *, you) subscription, so
@@ -1079,7 +1079,7 @@ Zulip subscription to these lines in ~/.zephyr.subs:
                 + "\n"
             )
 
-    for (cls, instance, recipient, reason) in skipped:
+    for cls, instance, recipient, reason in skipped:
         if verbose:
             if reason != "":
                 logger.info(f"  [{cls},{instance},{recipient}] ({reason})")

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -148,7 +148,6 @@ def add_default_arguments(
     patch_error_handling: bool = True,
     allow_provisioning: bool = False,
 ) -> argparse.ArgumentParser:
-
     if patch_error_handling:
 
         def custom_error_handling(self: argparse.ArgumentParser, message: str) -> None:
@@ -286,7 +285,6 @@ def generate_option_group(parser: optparse.OptionParser, prefix: str = "") -> op
 
 
 def init_from_options(options: Any, client: Optional[str] = None) -> "Client":
-
     if getattr(options, "provision", False):
         requirements_path = os.path.abspath(os.path.join(sys.path[0], "requirements.txt"))
         try:
@@ -521,7 +519,6 @@ class Client:
         assert self.zulip_version is not None
 
     def ensure_session(self) -> None:
-
         # Check if the session has been created already, and return
         # immediately if so.
         if self.session:
@@ -593,7 +590,7 @@ class Client:
         request = {}
         req_files = []
 
-        for (key, val) in orig_request.items():
+        for key, val in orig_request.items():
             if isinstance(val, str) or isinstance(val, str):
                 request[key] = val
             else:
@@ -728,7 +725,7 @@ class Client:
         if request is None:
             request = dict()
         marshalled_request = {}
-        for (k, v) in request.items():
+        for k, v in request.items():
             if v is not None:
                 marshalled_request[k] = v
         versioned_url = API_VERSTRING + (url if url is not None else "")
@@ -752,7 +749,6 @@ class Client:
             narrow = []
 
         def do_register() -> Tuple[str, int]:
-
             while True:
                 if event_types is None:
                     res = self.register(None, None, **kwargs)
@@ -841,7 +837,6 @@ class Client:
         return self.call_endpoint(url="messages", method="GET", request=message_filters)
 
     def check_messages_match_narrow(self, **request: Dict[str, Any]) -> Dict[str, Any]:
-
         """
         Example usage:
 
@@ -1278,7 +1273,6 @@ class Client:
         )
 
     def add_default_stream(self, stream_id: int) -> Dict[str, Any]:
-
         """
         Example usage:
 
@@ -1292,7 +1286,6 @@ class Client:
         )
 
     def get_user_by_id(self, user_id: int, **request: Any) -> Dict[str, Any]:
-
         """
         Example usage:
 
@@ -1306,7 +1299,6 @@ class Client:
         )
 
     def deactivate_user_by_id(self, user_id: int) -> Dict[str, Any]:
-
         """
         Example usage:
 
@@ -1319,7 +1311,6 @@ class Client:
         )
 
     def reactivate_user_by_id(self, user_id: int) -> Dict[str, Any]:
-
         """
         Example usage:
 
@@ -1332,7 +1323,6 @@ class Client:
         )
 
     def update_user_by_id(self, user_id: int, **request: Any) -> Dict[str, Any]:
-
         """
         Example usage:
 

--- a/zulip_bots/zulip_bots/bots/define/test_define.py
+++ b/zulip_bots/zulip_bots/bots/define/test_define.py
@@ -7,7 +7,6 @@ class TestDefineBot(BotTestCase, DefaultTests):
     bot_name = "define"
 
     def test_bot(self) -> None:
-
         # Only one type(noun) of word.
         bot_response = (
             "**cat**:\n\n* (**noun**) a small domesticated carnivorous mammal "

--- a/zulip_bots/zulip_bots/bots/flock/flock.py
+++ b/zulip_bots/zulip_bots/bots/flock/flock.py
@@ -14,6 +14,7 @@ You can send messages to any Flock user associated with your account from Zulip.
 *Syntax*: **@botname to: message** where `to` is **firstName** of recipient.
 """
 
+
 # Matches the recipient name provided by user with list of users in his contacts.
 # If matches, returns the matched User's ID
 def find_recipient_id(users: List[Any], recipient_name: str) -> str:

--- a/zulip_bots/zulip_bots/bots/game_of_fifteen/game_of_fifteen.py
+++ b/zulip_bots/zulip_bots/bots/game_of_fifteen/game_of_fifteen.py
@@ -5,7 +5,6 @@ from zulip_bots.game_handler import BadMoveException, GameAdapter
 
 
 class GameOfFifteenModel:
-
     final_board = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
 
     initial_board = [[8, 7, 6], [5, 4, 3], [2, 1, 0]]
@@ -84,7 +83,6 @@ class GameOfFifteenModel:
 
 
 class GameOfFifteenMessageHandler:
-
     tiles = {
         "0": ":grey_question:",
         "1": ":one:",

--- a/zulip_bots/zulip_bots/bots/incident/incident.py
+++ b/zulip_bots/zulip_bots/bots/incident/incident.py
@@ -82,7 +82,7 @@ def parse_answer(query: str) -> Tuple[str, str]:
 def generate_ticket_id(storage: Any) -> str:
     try:
         incident_num = storage.get("ticket_id")
-    except (KeyError):
+    except KeyError:
         incident_num = 0
     incident_num += 1
     incident_num = incident_num % (1000)

--- a/zulip_bots/zulip_bots/bots/merels/libraries/game.py
+++ b/zulip_bots/zulip_bots/bots/merels/libraries/game.py
@@ -62,17 +62,14 @@ def beat(message, topic_name, merels_storage):
     if match is None:
         return unknown_command()
     if match.group(1) is not None and match.group(2) is not None and match.group(3) is not None:
-
         responses = ""
         command = match.group(1)
 
         if command.lower() == "move":
-
             p1 = [int(x) for x in match.group(2).split(",")]
             p2 = [int(x) for x in match.group(3).split(",")]
 
             if mechanics.get_take_status(topic_name, merels_storage) == 1:
-
                 raise BadMoveException("Take is required to proceed." " Please try again.\n")
 
             responses += mechanics.move_man(topic_name, p1, p2, merels_storage) + "\n"

--- a/zulip_bots/zulip_bots/bots/stack_overflow/test_stack_overflow.py
+++ b/zulip_bots/zulip_bots/bots/stack_overflow/test_stack_overflow.py
@@ -6,7 +6,6 @@ class TestStackoverflowBot(BotTestCase, DefaultTests):
     bot_name = "stack_overflow"
 
     def test_bot(self) -> None:
-
         # Single-word query
         bot_request = "restful"
         bot_response = """For search term:restful

--- a/zulip_bots/zulip_bots/bots/trivia_quiz/trivia_quiz.py
+++ b/zulip_bots/zulip_bots/bots/trivia_quiz/trivia_quiz.py
@@ -92,7 +92,6 @@ def get_trivia_quiz() -> Dict[str, Any]:
 
 
 def get_trivia_payload() -> Dict[str, Any]:
-
     url = "https://opentdb.com/api.php?amount=1&type=multiple"
 
     try:

--- a/zulip_bots/zulip_bots/bots/weather/test_weather.py
+++ b/zulip_bots/zulip_bots/bots/weather/test_weather.py
@@ -31,7 +31,6 @@ class TestWeatherBot(BotTestCase, DefaultTests):
             self._test("", self.help_content)
 
     def test_bot(self) -> None:
-
         # City query
         bot_response = "Weather in New York, US:\n71.33 F / 21.85 C\nMist"
         self._test("New York", bot_response, "test_only_city")

--- a/zulip_bots/zulip_bots/bots/wikipedia/test_wikipedia.py
+++ b/zulip_bots/zulip_bots/bots/wikipedia/test_wikipedia.py
@@ -6,7 +6,6 @@ class TestWikipediaBot(BotTestCase, DefaultTests):
     bot_name = "wikipedia"
 
     def test_bot(self) -> None:
-
         # Single-word query
         bot_request = "happy"
         bot_response = """For search term:happy

--- a/zulip_bots/zulip_bots/bots/youtube/youtube.py
+++ b/zulip_bots/zulip_bots/bots/youtube/youtube.py
@@ -44,7 +44,6 @@ class YoutubeHandler:
             logging.warning("Bad connection")
 
     def handle_message(self, message: Dict[str, str], bot_handler: BotHandler) -> None:
-
         if message["content"] == "" or message["content"] == "help":
             bot_handler.send_reply(message, self.help_content)
         else:
@@ -55,7 +54,6 @@ class YoutubeHandler:
 
 
 def search_youtube(query: str, key: str, region: str, max_results: int = 1) -> List[List[str]]:
-
     videos = []
     params = {
         "part": "id,snippet",
@@ -96,7 +94,6 @@ def get_command_query(message: Dict[str, str]) -> Tuple[Optional[str], str]:
 def get_bot_response(
     query: Optional[str], command: Optional[str], config_info: Dict[str, str]
 ) -> str:
-
     key = config_info["key"]
     max_results = int(config_info["number_of_results"])
     region = config_info["video_region"]

--- a/zulip_bots/zulip_bots/lib.py
+++ b/zulip_bots/zulip_bots/lib.py
@@ -176,7 +176,6 @@ def use_storage(storage: BotStorage, keys: List[str]) -> Iterator[BotStorage]:
 
 
 class BotHandler(Protocol):
-
     user_id: int
     email: str
     full_name: str

--- a/zulip_bots/zulip_bots/test_lib.py
+++ b/zulip_bots/zulip_bots/test_lib.py
@@ -145,7 +145,7 @@ class BotTestCase(unittest.TestCase):
         # Start a new message handler for the full conversation.
         bot, bot_handler = self._get_handlers()
 
-        for (request, expected_response) in conversation:
+        for request, expected_response in conversation:
             message = self.make_request_message(request)
             bot_handler.reset_transcript()
             bot.handle_message(message, bot_handler)

--- a/zulip_bots/zulip_bots/tests/test_run.py
+++ b/zulip_bots/zulip_bots/tests/test_run.py
@@ -13,7 +13,6 @@ from zulip_bots.lib import extract_query_without_mention
 
 
 class TestDefaultArguments(TestCase):
-
     our_dir = os.path.dirname(__file__)
     path_to_bot = os.path.abspath(os.path.join(our_dir, "../bots/giphy/giphy.py"))
     packaged_bot_module = MagicMock(__version__="1.0.0")


### PR DESCRIPTION
Newer pull requests are getting linter errors to reformat files due to updates in the upstream.
This reformats the affected files using black, and pin it in `requirements.txt`; fixes a mypy error for a missing return type annotation.
However, I think we need to look into options like Poetry to do dependencies versioning properly in future follow-ups.