### PR TITLE
Do not send heartbeat events to clients.

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -819,6 +819,15 @@ class Client:
 
             for event in res["events"]:
                 last_event_id = max(last_event_id, int(event["id"]))
+
+                if event["type"] == "heartbeat":
+                    # Heartbeat events are sent to clients regardless
+                    # of the client's requested event types, and are
+                    # intended to be an internal part of the Zulip
+                    # longpolling protocol, not something that clients
+                    # need to handle.
+                    continue
+
                 callback(event)
 
     def call_on_each_message(


### PR DESCRIPTION
I tested this with https://github.com/showell/zulip-api-examples/blob/main/heartbeat_bug.py.

See https://chat.zulip.org/#narrow/stream/137-feedback/topic/api.20client.20silent.20failure for more context.