### PR TITLE
Remove unnecessary "sender" in request data

### DIFF
--- a/zulip/integrations/rss/rss-bot
+++ b/zulip/integrations/rss/rss-bot
@@ -182,7 +182,6 @@ def send_zulip(entry: Any, feed_name: str) -> Dict[str, Any]:
 
     message = {
         "type": "stream",
-        "sender": opts.zulip_email,
         "to": opts.stream,
         "subject": elide_subject(feed_name),
         "content": content,


### PR DESCRIPTION
I've experienced that `rss-bot` works fine when using config file, but fails when `--site`, `--api-key`, and `--user` are provided via command line. The error is the following:
```
{'result': 'error', 'msg': 'Invalid mirrored message', 'code': 'BAD_REQUEST'}
```
Debugging shows that in the latter case `rss-bot` calls `zulip.Client.send_message()` with `"sender"` field in `message_data`. In the former case `"sender"` is `None`. Clearly, it is a bug that `rss-bot`'s behaviour depends on `--user` being provided on the command line.

`"sender"` field in request causes [this exception](https://github.com/zulip/zulip/blob/e26f9180c16f6be088209afbf3a05fd0c4767872/zerver/views/message_send.py#L227) on the server side.
Judging by surrounding code, `"sender"` is only expected together with a [specific set of clients](https://github.com/zulip/zulip/blob/e26f9180c16f6be088209afbf3a05fd0c4767872/zerver/views/message_send.py#L186). `rss-bot` uses a different one:
https://github.com/zulip/python-zulip-api/blob/1b8f1d6e5170b49fd370e74b37b2fc0b936d22a4/zulip/integrations/rss/rss-bot#L204
Therefore I think, that providing `"sender"` is totally unnecessary.