### PR TITLE
merels: Convert incorrectly shared class variable to instance variable

### DIFF
--- a/zulip_bots/zulip_bots/bots/merels/merels.py
+++ b/zulip_bots/zulip_bots/bots/merels/merels.py
@@ -6,9 +6,8 @@ from .libraries import database, game, game_data, mechanics
 
 
 class Storage:
-    data = {}
-
     def __init__(self, topic_name):
+        self.data = {}
         self.data[topic_name] = '["X", 0, 0, "NNNNNNNNNNNNNNNNNNNNNNNN", "", 0]'
 
     def put(self, topic_name, value: str):


### PR DESCRIPTION
I don’t entirely understand the purpose of having a separate `MerelsStorage` class that’s only ever used with the fixed string `"merels"` as `topic_name`, but this class variable sharing was clearly and observably wrong.

Cc @amanagr (#324).