### PR TITLE
bridge_with_slack: Do not use a stale Zulip client for send_message.

### DIFF
--- a/zulip/integrations/bridge_with_slack/run-slack-bridge
+++ b/zulip/integrations/bridge_with_slack/run-slack-bridge
@@ -53,11 +53,17 @@ class SlackBridge:
         }
 
         # zulip-specific
-        self.zulip_client = zulip.Client(
-            email=self.zulip_config["email"],
-            api_key=self.zulip_config["api_key"],
-            site=self.zulip_config["site"],
-        )
+        def zulip_client_constructor() -> zulip.Client:
+            return zulip.Client(
+                email=self.zulip_config["email"],
+                api_key=self.zulip_config["api_key"],
+                site=self.zulip_config["site"],
+            )
+
+        self.zulip_client = zulip_client_constructor()
+        # Temporary workaround until
+        # https://github.com/zulip/python-zulip-api/issues/761 is fixed.
+        self.zulip_client_constructor = zulip_client_constructor
 
         # slack-specific
         self.slack_client = rtm
@@ -121,7 +127,7 @@ class SlackBridge:
                 subject=zulip_endpoint["topic"],
                 content=content,
             )
-            self.zulip_client.send_message(msg_data)
+            self.zulip_client_constructor().send_message(msg_data)
 
         self.slack_client.start()
 

--- a/zulip/integrations/bridge_with_slack/run-slack-bridge
+++ b/zulip/integrations/bridge_with_slack/run-slack-bridge
@@ -60,7 +60,6 @@ class SlackBridge:
         )
 
         # slack-specific
-        self.channel = self.slack_config["channel"]
         self.slack_client = rtm
         # Spawn a non-websocket client for getting the users
         # list and for posting messages in Slack.


### PR DESCRIPTION
This is based on https://github.com/zulip/zulip/commit/ff647dff03f178c329240c0e938d3fff8fbc5ab0, from #761.