### PR TITLE
zmirror: Drop empty zulip messages.

### DIFF
--- a/zulip/integrations/zephyr/zephyr_mirror_backend.py
+++ b/zulip/integrations/zephyr/zephyr_mirror_backend.py
@@ -554,6 +554,8 @@ def send_zulip_worker(zulip_queue: "Queue[ZephyrDict]", zulip_client: zulip.Clie
     while True:
         zeph = zulip_queue.get()
         try:
+            if zeph["content"] == "":
+                continue
             res = send_zulip(zulip_client, zeph)
             if res.get("result") != "success":
                 logger.error("Error relaying zephyr:\n%s\n%s", zeph, res)


### PR DESCRIPTION
Zulip will reject sending these, so there is no need to construct them.