### PR TITLE
rss-bot: Handle feed entries that lack a `title` field.

### DIFF
--- a/zulip/integrations/rss/rss-bot
+++ b/zulip/integrations/rss/rss-bot
@@ -177,7 +177,8 @@ def send_zulip(entry: Any, feed_name: str) -> Dict[str, Any]:
     if opts.unwrap:
         body = unwrap_text(body)
 
-    content = f"**[{entry.title}]({entry.link})**\n{strip_tags(body)}\n{entry.link}"
+    title = f"**[{entry.title}]({entry.link})**\n" if hasattr(entry, "title") else ""
+    content = f"{title}{strip_tags(body)}\n{entry.link}"
 
     if opts.math:
         content = content.replace("$", "$$")


### PR DESCRIPTION
Fixes #836.

Mastodon feed entries do not have a 'title' field.

We could handle this
- by not displaying the title, or
- by displaying the description as the title (truncated to a constant value)

This PR implements the former approach.

#### Screenshots

<details open>
<summary> Screenshots </summary>

**No Title (former approach)**
![No title](https://github.com/user-attachments/assets/b6e07410-b2c1-431c-a521-fd7ef7c8e7e4)

**Truncated Description - 60 characters (latter approach)**
![Truncated title](https://github.com/user-attachments/assets/40148e29-8fbb-476c-835f-87de00a6a3e7)

</details>
