### PR TITLE
Update the Git integration doc.

### DIFF
--- a/zulip/integrations/git/doc.md
+++ b/zulip/integrations/git/doc.md
@@ -1,31 +1,54 @@
-Get Zulip notifications for your Git repositories!
+# Zulip Git integration
 
-1. {!create-an-incoming-webhook.md!}
+Get Zulip notifications for pushes to your Git repositories!
 
-1. {!download-python-bindings.md!}
+Note that Zulip also offers integrations for [GitHub](./github),
+[GitLab](./gitlab) and various other
+[version control hosting services][other-integrations].
 
-1. {!create-channel.md!}
+{start_tabs}
 
-1. {!change-zulip-config-file.md!}
+1.  {!create-an-incoming-webhook.md!}
 
-    You may also need to change the value of `STREAM_NAME`.
+1.  {!download-python-bindings.md!}
 
-    You can specify the branches that will be used for notifications by modifying
-    the `commit_notice_destination` function. By default,
-    pushes to the `main`, `master`, and `test-post-receive` branches will result in a
-    notification.
+1.  If your Git server and your Zulip server are on the same machine,
+    symlink the `post-receive` hook of your Git repository in your Git
+    server by running:
 
-1. Symlink `/usr/local/share/zulip/integrations/git/zulip_git_config.py`
-   to the `.git/hooks` directory of your Git repository.
+    `ln -s {{ integration_path }}/post-receive your-repo.git/hooks/post-receive`
 
-1. Symlink `/usr/local/share/zulip/integrations/git/post-receive`
-   to the `.git/hooks` directory of your Git repository.
+    Otherwise, copy the `post-receive` hook to your Git repository's
+    `/hooks` directory.
+
+    The `post-receive` hook is triggered on every push to the repository.
+
+1.  {!change-zulip-config-file.md!}
+
+1.  Copy the config file to the same directory as the `post-receive` hook.
+
+    `cp {{ config_file_path }} your-repo.git/hooks`
 
 !!! tip ""
 
-    You can test the plugin without changing your `main` branch by
-    pushing to the `test-post-receive` branch.
+    Use the `test-post-receive` branch to test the integration without
+    modifying your `main` branch.
 
-{!congrats.md!}
+{end_tabs}
 
-![Git bot message](/static/images/integrations/git/001.png)
+### Configuration options
+
+In `{{ config_file_path }}`, you can set:
+
+- The channel where notifications are sent by updating the value of
+  `STREAM_NAME`. By default, notifications are sent to a channel named
+  "commits".
+
+- Which branches send notifications when pushed by updating the
+  `commit_notice_destination` function. By default, pushes to the `main`,
+  `master`, and `test-post-receive` branches will result in notifications.
+
+- The message format used in your Zulip notifications by updating the
+  `format_commit_message` function.
+
+[other-integrations]: ../version-control


### PR DESCRIPTION
Moved from [#32780](https://github.com/zulip/zulip/pull/32780), following the migration of the integration docs of the API integrations.

### Updates since last review

1. Warning note: "This integration is meant to be executed on your Git server." -> "This integration adds a `post-receive` hook to your Git repository on your Git server."
2. Rewritten instruction: "Symlink the `post-receive` hook of your Git repository by running:" -> "If your Git server and your Zulip server are on the same machine, symlink the `post-receive` hook of your Git repository in your Git server by running: ...command... Otherwise, copy the `post-receive` hook to your Git repository's `/hooks` directory."
3. Converted the tip "The post-receive hook is triggered on every push to the repository." to a line of text inside the instruction.
4. Opened [#34494](https://github.com/zulip/zulip/pull/34494) to update the installation macro.

<details>
<summary><h3>Screenshot</h3></summary>

![img](https://github.com/user-attachments/assets/9deca12b-61a2-4e9f-bb39-f44766817f92)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
