### PR TITLE
bots: migrate to new bs4 API

### DIFF
--- a/zulip_bots/zulip_bots/bots/google_search/google_search.py
+++ b/zulip_bots/zulip_bots/bots/google_search/google_search.py
@@ -18,7 +18,7 @@ def google_search(keywords: str) -> List[Dict[str, str]]:
     # Gets all search URLs
     search = soup.find(id="search")
     assert isinstance(search, Tag)
-    anchors = search.findAll("a")
+    anchors = search.find_all("a")
     results = []
 
     for a in anchors:


### PR DESCRIPTION
# PR Summary
Small PR - resolve the `bs4` deprecation warnings which you can see in the [CI logs](https://github.com/zulip/python-zulip-api/actions/runs/14700747060/job/41249729863#step:5:85):
```python
  /home/runner/work/python-zulip-api/python-zulip-api/zulip_bots/zulip_bots/bots/google_search/google_search.py:21: DeprecationWarning: Call to deprecated method findAll. (Replaced by find_all) -- Deprecated since version 4.0.0.
    anchors = search.findAll("a")
```