### PR TITLE
integration-docs: Update the screenshot path of Jira plugin

### DIFF
--- a/zulip/integrations/jira/doc.md
+++ b/zulip/integrations/jira/doc.md
@@ -68,4 +68,4 @@ String issueBaseUrl = "https://jira.COMPANY.com/browse/"
 
 {!congrats.md!}
 
-![Jira bot message](/static/images/integrations/jira/001.png)
+![Jira bot message](/static/images/integrations/jira-plugin/001.png)


### PR DESCRIPTION
It was previously using the path corresponding to the directory name on `python-zulip-api` (`jira`). It's now updated to use the name as used in the zulip/zulip repository.

This PR is intended to be merged only after https://github.com/zulip/zulip/pull/35592.
**Follow-up**: Once this PR is merged, we should remove the exclusion added to `test_integration_doc_endpoints` in `zulip/zulip`'s `test_docs.py`.

A previous version of the PR also updated Mercurial's `hg/001.png` -> `mercurial/001.png`, but I've since removed it, because of the hassle of tests failing whenever the images and docs are not in sync. So, I just added `image_dir` to point to `hg` in `integrations.py`.

It is unavoidable for the Jira plugin though, because `jira/001.png` is being used by the Jira webhook integration. And there's a difference in the template format used, between the webhook and plugin integrations. We could consider using the same image for both the integ docs only if we test and upate them both to use the same message formats.


<details>
<summary><h3>Screenshots</h3></summary>

Jira-plugin - before
![image](https://github.com/user-attachments/assets/08951fef-6390-404e-a0b0-2ddb8ce25a5d)
Jira-plugin - after
![image](https://github.com/user-attachments/assets/e4153973-cf28-4f7a-88d6-e10d7b7ed38b)

</details>

**How did you test this PR?**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
