### PR TITLE
Improve codebase's message template

### DIFF
--- a/zulip/integrations/codebase/zulip_codebase_mirror
+++ b/zulip/integrations/codebase/zulip_codebase_mirror
@@ -121,13 +121,11 @@ def handle_event(event: Dict[str, Any]) -> None:
         subject = f"Push to {branch} on {project}"
 
         if deleted_ref:
-            content = f"{actor_name} deleted branch {branch} from {project}"
+            content = f"{actor_name} deleted branch `{branch}` from {project}"
         else:
             if new_ref:
-                branch = f"new branch {branch}"
-            content = (
-                f"{actor_name} pushed {num_commits} commit(s) to {branch} in project {project}:\n\n"
-            )
+                branch = f"new branch `{branch}`"
+            content = f"{actor_name} pushed {num_commits} commit(s) to `{branch}` in project {project}:\n\n"
             for commit in raw_props.get("commits"):
                 ref = commit.get("ref")
                 url = make_url(f"projects/{project_link}/repositories/{repo_link}/commit/{ref}")


### PR DESCRIPTION
Add backticks for branch names.
Motivation: Updating example screenshots in integration docs.

---

**How did you test this PR?**
I did not test the changes.

---

I added the automatic changes on linting and formatting (on editor save) as the first commit, so that the actual functional changes are identifiable clearly in a separate commit.

Would we prefer to:
- Do this sort of formatting updates to all the files together? In that case, should I remove the changes in the first commit, and just add backticks to the templates in the format() calls?
- Merge this and worry about the rest later?

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
