### PR TITLE
Add remove_storage helper function (Fixes #637)

### DIFF
--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -1642,7 +1642,6 @@ class Client:
             method="PUT",
             request=request,
         )
-    
     def remove_storage(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """
         Example usage:

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -1642,6 +1642,7 @@ class Client:
             method="PUT",
             request=request,
         )
+
     def remove_storage(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """
         Example usage:
@@ -1653,6 +1654,7 @@ class Client:
             method="DELETE",
             request=request,
         )
+
     def get_storage(self, request: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Example usage:

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -1642,6 +1642,19 @@ class Client:
             method="PUT",
             request=request,
         )
+    
+    def remove_storage(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Example usage:
+
+        >>> client.remove_storage({'keys': ["entry 1"]})
+        {'result': 'success', 'msg': ''}
+        """
+        return self.call_endpoint(
+            url="bot_storage",
+            method="DELETE",
+            request=request,
+        )
 
     def get_storage(self, request: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -1653,7 +1653,6 @@ class Client:
             method="DELETE",
             request=request,
         )
-
     def get_storage(self, request: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Example usage:

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -1646,7 +1646,6 @@ class Client:
     def remove_storage(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """
         Example usage:
-
         >>> client.remove_storage({'keys': ["entry 1"]})
         {'result': 'success', 'msg': ''}
         """


### PR DESCRIPTION
Fixes #637.

This PR adds the missing `remove_storage` helper function to the Python API. It mirrors the existing `update_storage` implementation but uses the `DELETE` HTTP method as required.