### PR TITLE
fix: argument naming consistency

### DIFF
--- a/zulip_bots/zulip_bots/run.py
+++ b/zulip_bots/zulip_bots/run.py
@@ -19,7 +19,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 
 def parse_args() -> argparse.Namespace:
     usage = """
-        zulip-run-bot <bot_name> --config-file ~/zuliprc
+        zulip-run-bot <bot> --config-file ~/zuliprc
         zulip-run-bot --help
         """
 


### PR DESCRIPTION
Tiny change to fix naming consistency in usage description. The argument is referred to as `bot`, but in the usage description, it's referred to as `bot_name`.