### PR TITLE
fix(init): remove pip as a dependency

### DIFF
--- a/zulip_bots/setup.py
+++ b/zulip_bots/setup.py
@@ -50,7 +50,6 @@ setup(
         ],
     },
     install_requires=[
-        "pip",
         "zulip",
         "html2text",
         "lxml",


### PR DESCRIPTION
Changes:

- Removes large `pip` dependency by switching to calling the current python env's pip
- Fix a bug where the initialization will proceed even if dependencies failed to provision
- Fix unhandled dependency provisioning failure