### PR TITLE
do_api_query: Reset session on ConnectionError to fix stale connections

### DIFF
--- a/zulip/tests/test_do_api_query.py
+++ b/zulip/tests/test_do_api_query.py
@@ -1,0 +1,71 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+import requests
+import zulip
+
+
+def make_client() -> zulip.Client:
+    with patch.object(zulip.Client, "call_endpoint") as mock_call:
+        mock_call.return_value = {
+            "result": "success",
+            "zulip_version": "9.0.0",
+            "zulip_feature_level": 300,
+            "msg": "",
+        }
+        client = zulip.Client(
+            email="test@example.com",
+            api_key="deadbeef",
+            site="https://testserver",
+        )
+    return client
+
+
+class TestStaleConnectionRetry(unittest.TestCase):
+    def test_stale_connection_resets_session(self) -> None:
+        client = make_client()
+
+        # Simulate a session that has already been used (has_connected = True)
+        stale_session = MagicMock()
+        client.session = stale_session
+        client.has_connected = True
+
+        # First request raises ConnectionError (stale socket),
+        # second request succeeds
+        success_response = MagicMock()
+        success_response.status_code = 200
+        success_response.json.return_value = {"result": "success", "msg": ""}
+
+        stale_session.request.side_effect = requests.exceptions.ConnectionError("stale")
+
+        fresh_session = MagicMock()
+        fresh_session.request.return_value = success_response
+
+        original_ensure_session = zulip.Client.ensure_session
+
+        call_count = 0
+
+        def mock_ensure_session(self: zulip.Client) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call: leave the stale session in place
+                self.session = stale_session
+            else:
+                # Subsequent calls: provide a fresh session
+                self.session = fresh_session
+
+        with patch.object(zulip.Client, "ensure_session", mock_ensure_session):
+            result = client.do_api_query({}, "/api/v1/messages", method="POST")
+
+        # The stale session should have been closed
+        stale_session.close.assert_called_once()
+
+        # The result should come from the fresh session
+        self.assertEqual(result, {"result": "success", "msg": ""})
+
+        # ensure_session should have been called twice (once per loop iteration)
+        self.assertEqual(call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zulip/tests/test_do_api_query.py
+++ b/zulip/tests/test_do_api_query.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import requests
+
 import zulip
 
 

--- a/zulip/tests/test_do_api_query.py
+++ b/zulip/tests/test_do_api_query.py
@@ -1,5 +1,6 @@
 import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
+
 import requests
 import zulip
 
@@ -39,8 +40,6 @@ class TestStaleConnectionRetry(unittest.TestCase):
 
         fresh_session = MagicMock()
         fresh_session.request.return_value = success_response
-
-        original_ensure_session = zulip.Client.ensure_session
 
         call_count = 0
 

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -600,9 +600,6 @@ class Client:
 
         req_files = [(f.name, f) for f in files]
 
-        self.ensure_session()
-        assert self.session is not None
-
         query_state: Dict[str, Any] = {
             "had_error_retry": False,
             "request": request,
@@ -637,6 +634,9 @@ class Client:
                     print("Failed!")
 
         while True:
+            self.ensure_session()
+            assert self.session is not None
+
             try:
                 kwarg = "params" if method == "GET" else "data"
 
@@ -686,6 +686,9 @@ class Client:
                     raise UnrecoverableNetworkError(
                         "cannot connect to server " + self.base_url
                     ) from e
+                if self.session is not None:
+                    self.session.close()
+                    self.session = None
 
                 if error_retry(""):
                     continue


### PR DESCRIPTION
<!-- Describe your pull request here.-->
When a network middlebox silently drops an idle TCP connection, the next request raises a ConnectionError. Previously the retry logic would reuse the same dead session, failing up to 10 times. Now we close and null out the session on ConnectionError so ensure_session() creates a fresh one on the next retry.

This differs from #854 in that it reuses the existing error_retry machinery rather than adding a parallel retry system with separate timeout constants and retry counters.

Fixes: #761

<!-- If the PR changes output, always include screenshots or code blocks to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**How did you test this PR?**

Added a new automated test in zulip/tests/test_do_api_query.py that simulates a stale connection by having the first session raise a ConnectionError, then verifies that the session is closed and replaced with a fresh one, and that the request succeeds on retry.

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
