### PR TITLE
zulip_bots: Fix react() in StubBotHandler to pass full reaction data

### DIFF
--- a/zulip_bots/zulip_bots/test_lib.py
+++ b/zulip_bots/zulip_bots/test_lib.py
@@ -35,7 +35,9 @@ class StubBotHandler:
         return self.message_server.send(response_message)
 
     def react(self, message: Dict[str, Any], emoji_name: str) -> Dict[str, Any]:
-        return self.message_server.add_reaction(emoji_name)
+        return self.message_server.add_reaction(
+            dict(message_id=message["id"], emoji_name=emoji_name, reaction_type="unicode_emoji")
+        )
 
     def update_message(self, message: Dict[str, Any]) -> None:
         self.message_server.update(message)
@@ -126,6 +128,7 @@ class BotTestCase(unittest.TestCase):
             sender_full_name="Foo Test User",
             sender_id="123",
             content=content,
+            id=0,
         )
         return message
 


### PR DESCRIPTION
While investigating #790 (bot_handler.react only working in private messages),
I found an inconsistency in StubBotHandler.react() in test_lib.py that could
cause bots to behave differently in tests vs. production.

The react() method in StubBotHandler was passing only emoji_name to
message_server.add_reaction(), while the real ExternalBotHandler and
TerminalBotHandler implementations both pass the full reaction dict including
message_id and reaction_type. Additionally, mock messages constructed by
make_request_message() were missing an id field, which would cause any bot
test exercising react() to raise a KeyError.

Fixes: #790 (partial - fixes test framework inconsistency found while investigating)

**How did you test this PR?**

Ran the full test suite: 413 passed, 0 failed. (previously 2 failed)
Verified ruff and mypy report no issues on test_lib.py.

