### PR TITLE
zulip: Reset session on ConnectionError to fix stale connections.

### DIFF
--- a/zulip/tests/test_do_api_query.py
+++ b/zulip/tests/test_do_api_query.py
@@ -1,0 +1,83 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import requests
+
+import zulip
+
+
+class TestDoApiQuery(TestCase):
+    @patch("zulip.Client.get_server_settings")
+    def _make_client(self, mock_server_settings: MagicMock) -> zulip.Client:
+        mock_server_settings.return_value = {
+            "zulip_version": "1.0",
+            "zulip_feature_level": 0,
+        }
+        client = zulip.Client(
+            email="test@example.com",
+            api_key="fake-key",
+            site="https://example.com",
+        )
+        client.has_connected = True
+        return client
+
+    def test_session_reset_on_connection_error(self) -> None:
+        """When a ConnectionError occurs and the client has previously
+        connected, the stale session should be closed and replaced with
+        a fresh one so that the retry succeeds.
+        """
+        client = self._make_client()
+
+        stale_session = MagicMock(spec=requests.Session)
+        stale_session.request.side_effect = requests.exceptions.ConnectionError(
+            "Connection reset by peer"
+        )
+
+        fresh_session = MagicMock(spec=requests.Session)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"result": "success", "msg": ""}
+        fresh_session.request.return_value = mock_response
+
+        # Track how many sessions ensure_session has built.
+        sessions_created = 0
+
+        def mock_ensure_session(self: zulip.Client) -> None:
+            nonlocal sessions_created
+            if self.session is None:
+                sessions_created += 1
+                if sessions_created == 1:
+                    self.session = stale_session
+                else:
+                    self.session = fresh_session
+
+        with patch.object(zulip.Client, "ensure_session", mock_ensure_session):
+            result = client.do_api_query({}, "v1/messages", method="GET")
+
+        # The stale session should have been closed.
+        stale_session.close.assert_called_once()
+
+        # A fresh session should have been created for the retry.
+        self.assertEqual(sessions_created, 2)
+
+        # The request should ultimately succeed.
+        self.assertEqual(result["result"], "success")
+
+    def test_session_not_reset_when_never_connected(self) -> None:
+        """When the client has never successfully connected, a
+        ConnectionError should raise UnrecoverableNetworkError
+        without resetting the session.
+        """
+        client = self._make_client()
+        client.has_connected = False
+
+        mock_session = MagicMock(spec=requests.Session)
+        mock_session.request.side_effect = requests.exceptions.ConnectionError("Connection refused")
+        client.session = mock_session
+
+        with self.assertRaises(zulip.UnrecoverableNetworkError):
+            client.do_api_query({}, "v1/messages", method="GET")
+
+        # The session should NOT have been closed, since we never
+        # connected in the first place.
+        mock_session.close.assert_not_called()

--- a/zulip/zulip/__init__.py
+++ b/zulip/zulip/__init__.py
@@ -600,9 +600,6 @@ class Client:
 
         req_files = [(f.name, f) for f in files]
 
-        self.ensure_session()
-        assert self.session is not None
-
         query_state: Dict[str, Any] = {
             "had_error_retry": False,
             "request": request,
@@ -637,6 +634,9 @@ class Client:
                     print("Failed!")
 
         while True:
+            self.ensure_session()
+            assert self.session is not None
+
             try:
                 kwarg = "params" if method == "GET" else "data"
 
@@ -686,6 +686,14 @@ class Client:
                     raise UnrecoverableNetworkError(
                         "cannot connect to server " + self.base_url
                     ) from e
+
+                # The session may be holding a stale TCP connection
+                # that was silently dropped by a network middlebox.
+                # Close it so ensure_session() will open a fresh
+                # connection on the next attempt.
+                if self.session is not None:
+                    self.session.close()
+                self.session = None
 
                 if error_retry(""):
                     continue


### PR DESCRIPTION
## Overview

When a network middlebox silently drops an idle TCP connection,
`requests.Session` keeps that dead socket in its connection pool. The next
API call tries to reuse it and raises a `ConnectionError`. Previously the
retry loop in `do_api_query` caught this error but never closed the broken
session, so every retry attempt reused the same dead connection and failed.

## Root Cause

`ensure_session()` was called once before the `while True` loop, so after a
`ConnectionError` the session was never rebuilt on retry. All 10 retries
attempted to send requests over the same stale TCP connection.

## Fix

Two minimal changes to `do_api_query`:

1. Move `ensure_session()` inside the `while True` loop so it runs on every
2.    iteration.
3. 2. On `ConnectionError`, close and null out `self.session` before retrying.
4.    The next iteration calls `ensure_session()`, sees `None`, and creates a
5.    fresh connection.
```python
if self.session is not None:
    self.session.close()
self.session = None
```

The existing `error_retry` machinery is reused completely unchanged. No new
parameters, timeouts, or retry counters were added.

## Why This Approach

PR #854 added a parallel retry system with new timeouts and keep-alive
headers - too broad. PR #913 was on the right track (session reset) but
had linting failures and stalled. This PR takes the same minimal approach
with full lint compliance and proper test coverage.

## Test Results

```
============================= test session starts ==============================
platform darwin -- Python 3.9.6, pytest-8.4.2

zulip/tests/test_do_api_query.py::TestDoApiQuery::test_session_not_reset_when_never_connected PASSED [ 50%]
zulip/tests/test_do_api_query.py::TestDoApiQuery::test_session_reset_on_connection_error PASSED [100%]

========================= 2 passed in 2.14s ============================
```

Full project suite (437 tests, 0 failures):
```
========================= 437 passed, 5 warnings in 4.57s ========================
```

Linting (ruff + mypy):
```
mypy | Success: no issues found in 72 source files
ruff | All checks passed.
```

Gitlint:
```
gitlint --msg-filename /dev/stdin   # exit 0, no violations
```

## Tests Added

`zulip/tests/test_do_api_query.py`:

- `test_session_reset_on_connection_error` - First session raises
-   `ConnectionError`; verifies the stale session is `close()`d, a fresh
-   session is created, and the request succeeds on retry.
- - `test_session_not_reset_when_never_connected` - `ConnectionError` before
-   first successful connection raises `UnrecoverableNetworkError` without
-   touching the session.
Fixes #761.